### PR TITLE
Update htmlSafe import

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -8,7 +8,7 @@ import layout from '../templates/components/attach-popover';
 import { cancel, debounce, later, next, run } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import { guidFor } from '@ember/object/internals';
-import { htmlSafe, isHTMLSafe } from '@ember/string';
+import { htmlSafe, isHTMLSafe } from '@ember/template';
 import { stripInProduction } from 'ember-attacher/-debug/helpers';
 import { warn } from '@ember/debug';
 import { isEmpty } from '@ember/utils';

--- a/tests/integration/components/attach-tooltip-test.js
+++ b/tests/integration/components/attach-tooltip-test.js
@@ -2,7 +2,7 @@ import QUnit, { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 QUnit.assert.contains = function(actual, expected, message) {
   this.pushResult({


### PR DESCRIPTION
Importing `htmlSafe` from `@ember/string` has been deprecated in favor of importing it from `@ember/template`. When deploying my app running on Ember 3.28, I get an error when I try to open an ember-attacher popover because of this import. Updating the `htmlSafe` import to come from `@ember/template` fixes the issue.