### PR TITLE
Convert to Glimmer component

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,8 +67,5 @@ updates:
     - 5.6.4
     - 5.6.5
     - 5.7.0
-  - dependency-name: ember-power-select
-    versions:
-    - 4.1.3
   commit-message:
     prefix: "[chore]"

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -33,6 +33,10 @@ export default class AttachPopover extends Component {
     return this.args.arrow ?? this._config.arrow ?? DEFAULTS.arrow;
   }
 
+  get autoUpdate() {
+    return this.args.autoUpdate ?? this._config.autoUpdate ?? DEFAULTS.autoUpdate;
+  }
+
   get animation() {
     return this.args.animation || this._config.animation || DEFAULTS.animation;
   }

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -293,29 +293,7 @@ export default class AttachPopover extends Component {
   @action
   _ensureArgumentsAreValid() {
     stripInProduction(() => {
-      // eslint-disable-next-line ember/no-attrs-in-components
-      const attrs = this.args || {};
-      const userDefaults = this._config;
-
-      let arrow;
-      if (attrs.arrow !== undefined) {
-        arrow = attrs.arrow;
-      } else if (userDefaults.arrow !== undefined) {
-        arrow = userDefaults.arrow;
-      } else {
-        arrow = DEFAULTS.arrow;
-      }
-
-      let animation;
-      if (attrs.animation !== undefined) {
-        animation = attrs.animation;
-      } else if (userDefaults.animation !== undefined) {
-        animation = userDefaults.animation;
-      } else {
-        animation = DEFAULTS.animation;
-      }
-
-      if (arrow && animation === 'fill') {
+      if (this.arrow && this.isFillAnimation) {
         warn('Animation: \'fill\' is not compatible with arrow: true', { id: 70015 });
       }
 
@@ -424,7 +402,7 @@ export default class AttachPopover extends Component {
   }
 
   @action
-  _isShownChanged() {
+  onIsShownChange() {
     const isShown = this.isShown;
 
     if (isShown === true && this._isHidden) {
@@ -794,7 +772,8 @@ export default class AttachPopover extends Component {
   }
 
   @action
-  didUpdateOptions() {
+  onOptionsChange() {
+    this._ensureArgumentsAreValid();
     this._update();
   }
 

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -19,7 +19,7 @@ export default class AttachPopover extends Component {
   @tracked parentElement = null;
   @tracked _isStartingAnimation = false;
   @tracked _arrowElement = null;
-
+  @tracked _currentTarget = null;
   // This is set to true when the popover is shown in order to override lazyRender=false
   @tracked _mustRender = false;
   @tracked _transitionDuration = 0;
@@ -111,10 +111,6 @@ export default class AttachPopover extends Component {
 
   get useCapture() {
     return this.args.useCapture ?? this._config.useCapture ?? DEFAULTS.useCapture;
-  }
-
-  get _currentTarget() {
-    return this.args.explicitTarget || this.parentElement;
   }
 
   get isFillAnimation() {
@@ -345,7 +341,7 @@ export default class AttachPopover extends Component {
 
   _initializeAttacher() {
     this._removeEventListeners();
-
+    this._currentTarget = this.args.explicitTarget || this.parentElement;
     this._addListenersForShowEvents();
 
     if (!this._isHidden || this.isShown) {
@@ -396,8 +392,7 @@ export default class AttachPopover extends Component {
   }
 
   @action
-  _targetOrTriggersChanged() {
-    console.log('_targetOrTriggersChanged!');
+  onTargetOrTriggerChanged() {
     this._initializeAttacher();
   }
 

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -1,12 +1,6 @@
-import classic from 'ember-classic-decorator';
-import { tagName, layout as templateLayout } from '@ember-decorators/component';
-import { observes } from '@ember-decorators/object';
-import { action, computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
-// eslint-disable-next-line ember/no-classic-components
-import Component from '@ember/component';
-import DEFAULTS from '../defaults';
-import layout from '../templates/components/attach-popover';
+import { set } from '@ember/object';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
 import { cancel, debounce, later, next, run } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import { guidFor } from '@ember/object/internals';
@@ -16,45 +10,91 @@ import { warn, assert } from '@ember/debug';
 import { isEmpty, typeOf } from '@ember/utils';
 import { autoUpdate, computePosition, arrow, flip } from '@floating-ui/dom';
 import { buildWaiter } from '@ember/test-waiters';
+import { tracked } from '@glimmer/tracking';
+import DEFAULTS from '../defaults';
 
 const animationTestWaiter = buildWaiter('attach-popover');
 
-@classic
-@templateLayout(layout)
-@tagName('')
+// @templateLayout(layout)
 export default class AttachPopover extends Component {
-  @equal('animation', 'fill') isFillAnimation;
+  @tracked parentNotFound = true;
+  @tracked parentElement = null;
+  @tracked _isStartingAnimation = false;
+  @tracked _arrowElement = null;
 
+  // This is set to true when the popover is shown in order to override lazyRender=false
+  @tracked _mustRender = false;
+  @tracked _transitionDuration = 0;
+  _floatingElement = null;
   configKey = 'popover';
   /**
    * ================== PUBLIC CONFIG OPTIONS ==================
    */
+  get arrow() {
+    return this.args.arrow ?? this._config.arrow ?? DEFAULTS.arrow;
+  }
 
-  animation = DEFAULTS.animation;
+  get animation() {
+    return this.args.animation || this._config.animation || DEFAULTS.animation;
+  }
 
-  arrow = DEFAULTS.arrow;
-  flip = DEFAULTS.flip;
-  hideDelay = DEFAULTS.hideDelay;
+  get flip() {
+    return this.args.flip ?? this._config.flip ?? DEFAULTS.flip;
+  }
+
+  get hideDelay() {
+    return this.args.hideDelay ?? this._config.hideDelay ?? DEFAULTS.hideDelay;
+  }
+
   hideDuration = DEFAULTS.hideDuration;
-  hideOn = DEFAULTS.hideOn;
-  interactive = DEFAULTS.interactive;
+
+  get hideOn() {
+    return this.args.hideOn || this._config.hideOn || DEFAULTS.hideOn;
+  }
+
+  get interactive() {
+    return this.args.interactive || this._config.interactive || DEFAULTS.interactive;
+  }
+
   isOffset = DEFAULTS.isOffset;
-  isShown = DEFAULTS.isShown;
-  lazyRender = DEFAULTS.lazyRender;
-  onChange = null;
-  placement = DEFAULTS.placement;
-  floatingElementContainer = DEFAULTS.floatingElementContainer;
+
+  get isShown() {
+    return this.args.isShown ?? this._config.isShown ?? DEFAULTS.isShown;
+  }
+  get lazyRender() {
+    return this.args.lazyRender ?? this._config.lazyRender ?? DEFAULTS.lazyRender;
+  }
+
+  get placement() {
+    return this.args.placement ?? this._config.placement ?? DEFAULTS.placement;
+  }
+
+  get floatingElementContainer() {
+    return this.args.floatingElementContainer || this._config.floatingElementContainer || DEFAULTS.floatingElementContainer;
+  }
+
   floatingUiOptions = DEFAULTS.floatingUiOptions;
-  explicitTarget = null;
-  renderInPlace = DEFAULTS.renderInPlace;
+  get renderInPlace() {
+    return this.args.renderInPlace ?? this._config.renderInPlace ?? DEFAULTS.renderInPlace;
+  }
   showDelay = DEFAULTS.showDelay;
   showDuration = DEFAULTS.showDuration;
-  showOn = DEFAULTS.showOn;
-  style = DEFAULTS.style;
-  useCapture = DEFAULTS.useCapture;
 
-  _arrowElement = null;
-  _floatingElement = null;
+  get showOn() {
+    if (this.args.showOn === null) {
+      return null
+    }
+
+    return this.args.showOn ?? this._config.showOn ?? DEFAULTS.showOn;
+  }
+
+  get style() {
+    return this.args.style ?? this._config.style ?? DEFAULTS.style;
+  }
+
+  get useCapture() {
+    return this.args.useCapture ?? this._config.useCapture ?? DEFAULTS.useCapture;
+  }
 
   // Exposed via the named yield to enable custom hide events
   @action
@@ -62,24 +102,29 @@ export default class AttachPopover extends Component {
     this._hide();
   }
 
+  get _currentTarget() {
+    return this.args.explicitTarget || this.parentElement;
+  }
+
+  get isFillAnimation() {
+    return this.animation === 'fill';
+  }
+
   // The circle element needs a special duration that is slightly faster than the floating element's
   // transition, this prevents text from appearing outside the circle as it fills the background
-  @computed('_transitionDuration')
   get _circleTransitionDuration() {
     return htmlSafe(
       `transition-duration: ${Math.round(this._transitionDuration / 1.25)}ms`
     );
   }
 
-  @computed('class', 'arrow', 'animation', '_isStartingAnimation')
   get _class() {
     const showOrHideClass = `ember-attacher-${this._isStartingAnimation ? 'show' : 'hide'}`;
     const arrowClass = `ember-attacher-${this.arrow ? 'with' : 'without'}-arrow`;
 
-    return `ember-attacher-${this.animation} ${this.class || ''} ${showOrHideClass} ${arrowClass}`;
+    return [`ember-attacher-${this.animation}`, this.class ?? '' ,showOrHideClass, arrowClass].filter(Boolean).join(' ');
   }
 
-  @computed('style', '_transitionDuration')
   get _style() {
     const style = this.style;
     const transitionDuration = this._transitionDuration;
@@ -97,7 +142,6 @@ export default class AttachPopover extends Component {
     return getOwner(this).resolveRegistration('config:environment').emberAttacher || {};
   }
 
-  @computed('_envConfig', 'configKey')
   get _config() {
     return {
       ...this._envConfig,
@@ -105,7 +149,6 @@ export default class AttachPopover extends Component {
     };
   }
 
-  @computed('hideOn')
   get _hideOn() {
     let hideOn = this.hideOn;
 
@@ -116,12 +159,10 @@ export default class AttachPopover extends Component {
     return hideOn === null ? [] : hideOn.split(' ');
   }
 
-  // eslint-disable-next-line ember/require-computed-property-dependencies
-  @computed('arrow', 'flip', 'middleware', '_arrowElement')
   get _middleware() {
     // Copy the middleware since we might write to the provided array
     const middleware
-      = this.middleware ? [...this.middleware] : [];
+      = this.args.middleware ? [...this.args.middleware] : [];
 
     if (this.arrow && this._arrowElement && !middleware.find(name => name === 'arrow')) {
       middleware.push(arrow({ element: this._arrowElement }));
@@ -141,14 +182,13 @@ export default class AttachPopover extends Component {
     return middleware;
   }
 
-  @computed('_parentFinder.parentNode', '_renderInPlace', 'floatingElementContainer')
   get _floatingElementContainer() {
     const maybeContainer = this.floatingElementContainer;
     const renderInPlace = this._renderInPlace;
     let floatingElementContainer;
 
     if (renderInPlace) {
-      floatingElementContainer = this._parentFinder.parentNode;
+      floatingElementContainer = this.parentElement;
     } else if (maybeContainer instanceof Element) {
       floatingElementContainer = maybeContainer;
     } else if (typeof maybeContainer === 'string') {
@@ -164,7 +204,6 @@ export default class AttachPopover extends Component {
     return floatingElementContainer;
   }
 
-  @computed('renderInPlace')
   get _renderInPlace() {
     // self.document is undefined in Fastboot, so we have to render in
     // place for the floating element to show up at all.
@@ -178,7 +217,7 @@ export default class AttachPopover extends Component {
       });
       return;
     }
-    const onChange = this.onChange;
+    const onChange = this.args.onChange;
 
     if (delay) {
       this._delayedVisibilityToggle = later(this, () => {
@@ -210,10 +249,6 @@ export default class AttachPopover extends Component {
     }
   }
 
-  // This is set to true when the popover is shown in order to override lazyRender=false
-  _mustRender = false;
-
-  @computed('showOn')
   get _showOn() {
     let showOn = this.showOn;
 
@@ -224,26 +259,87 @@ export default class AttachPopover extends Component {
     return showOn === null ? [] : showOn.split(' ');
   }
 
-  _transitionDuration = 0;
+  @action
+  onParentFinderInsert(element) {
+    this.parentElement = element.parentElement;
+    this._initializeAttacher()
+  }
 
-  /**
-   * ================== LIFECYCLE HOOKS ==================
-   */
+  @action
+  _ensureArgumentsAreValid() {
+    stripInProduction(() => {
+      // eslint-disable-next-line ember/no-attrs-in-components
+      const attrs = this.args || {};
+      const userDefaults = this._config;
 
-  init() {
-    super.init(...arguments);
+      let arrow;
+      if (attrs.arrow !== undefined) {
+        arrow = attrs.arrow;
+      } else if (userDefaults.arrow !== undefined) {
+        arrow = userDefaults.arrow;
+      } else {
+        arrow = DEFAULTS.arrow;
+      }
 
-    // Used to determine the attachments initial parent element
-    // eslint-disable-next-line ember/no-assignment-of-untracked-properties-used-in-tracking-contexts
-    this._parentFinder = self.document ? self.document.createTextNode('') : '';
+      let animation;
+      if (attrs.animation !== undefined) {
+        animation = attrs.animation;
+      } else if (userDefaults.animation !== undefined) {
+        animation = userDefaults.animation;
+      } else {
+        animation = DEFAULTS.animation;
+      }
 
-    // Holds the current floating ui target so event listeners can be removed if the target changes
-    this._currentTarget = null;
+      if (arrow && animation === 'fill') {
+        warn('Animation: \'fill\' is not compatible with arrow: true', { id: 70015 });
+      }
+
+      if (this.useCapture !== this._lastUseCaptureArgumentValue) {
+        warn(
+          'The value of the useCapture argument was mutated',
+          { id: 'ember-attacher.use-capture-mutated' }
+        );
+      }
+    });
+  }
+
+  _setUserSuppliedDefaults() {
+    const userDefaults = this._config;
+
+    // Exit early if no custom defaults are found
+    if (!Object.keys(userDefaults).length) {
+      return;
+    }
+
+    const args = this.args || {};
+
+    for (const key in userDefaults) {
+      stripInProduction(() => {
+        // eslint-disable-next-line no-prototype-builtins
+        if (!['popover','tooltip', 'class'].includes(key) && !DEFAULTS.hasOwnProperty(key)) {
+          warn(`Unknown property given as an ember-attacher default: ${key}`, { id: 700152 });
+        }
+      });
+
+      // Don't override args manually passed into the component
+      if (args[key] === undefined) {
+        if (key === 'arrow') {
+          set(this, 'arrow', userDefaults[key]);
+        } else {
+          this[key] = userDefaults[key];
+        }
+      }
+    }
+  }
+
+  get id() {
+    return this.args.id || `${guidFor(this)}-floating`;
+  }
+  constructor() {
+    super(...arguments);
 
     // The debounced _hide() and _show() are stored here so they can be cancelled when necessary
     this._delayedVisibilityToggle = null;
-
-    this.id = this.id || `${guidFor(this)}-floating`;
 
     // The final source of truth on whether or not all _hide() or _show() actions have completed
     this._isHidden = true;
@@ -272,98 +368,11 @@ export default class AttachPopover extends Component {
     this._showAfterDelay = this._showAfterDelay.bind(this);
 
     this._setUserSuppliedDefaults();
-  }
-
-  // eslint-disable-next-line ember/no-component-lifecycle-hooks
-  didReceiveAttrs() {
-    super.didReceiveAttrs(...arguments);
-
-    stripInProduction(() => {
-      // eslint-disable-next-line ember/no-attrs-in-components
-      const attrs = this.attrs || {};
-      const userDefaults = this._config;
-
-      let arrow;
-      if (attrs.arrow !== undefined) {
-        arrow = attrs.arrow.value;
-      } else if (userDefaults.arrow !== undefined) {
-        arrow = userDefaults.arrow;
-      } else {
-        arrow = DEFAULTS.arrow;
-      }
-
-      let animation;
-      if (attrs.animation !== undefined) {
-        animation = attrs.animation.value;
-      } else if (userDefaults.animation !== undefined) {
-        animation = userDefaults.animation;
-      } else {
-        animation = DEFAULTS.animation;
-      }
-
-      if (arrow && animation === 'fill') {
-        warn('Animation: \'fill\' is not compatible with arrow: true', { id: 70015 });
-      }
-
-      this._lastUseCaptureArgumentValue = this.useCapture;
-    });
-  }
-
-  // eslint-disable-next-line ember/no-component-lifecycle-hooks
-  didUpdateAttrs() {
-    super.didUpdateAttrs(...arguments);
-
-    stripInProduction(() => {
-      if (this.useCapture !== this._lastUseCaptureArgumentValue) {
-        warn(
-          'The value of the useCapture argument was mutated',
-          { id: 'ember-attacher.use-capture-mutated' }
-        );
-      }
-    })
-  }
-
-  _setUserSuppliedDefaults() {
-    const userDefaults = this._config;
-
-    // Exit early if no custom defaults are found
-    if (!Object.keys(userDefaults).length) {
-      return;
-    }
-
-    // eslint-disable-next-line ember/no-attrs-in-components
-    const attrs = this.attrs || {};
-
-    for (const key in userDefaults) {
-      stripInProduction(() => {
-        // eslint-disable-next-line no-prototype-builtins
-        if (!['popover','tooltip', 'class'].includes(key) && !DEFAULTS.hasOwnProperty(key)) {
-          warn(`Unknown property given as an ember-attacher default: ${key}`, { id: 700152 });
-        }
-      });
-
-      // Don't override attrs manually passed into the component
-      if (attrs[key] === undefined) {
-        if (key === 'arrow') {
-          this.set('arrow', userDefaults[key]);
-        } else {
-          this[key] = userDefaults[key];
-        }
-      }
-    }
-  }
-
-  // eslint-disable-next-line ember/no-component-lifecycle-hooks
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-
-    this._initializeAttacher();
+    this._lastUseCaptureArgumentValue = this.useCapture;
   }
 
   _initializeAttacher() {
     this._removeEventListeners();
-
-    this.set('_currentTarget', this.explicitTarget || this._parentFinder.parentNode);
 
     this._addListenersForShowEvents();
 
@@ -389,9 +398,8 @@ export default class AttachPopover extends Component {
     });
   }
 
-  // eslint-disable-next-line ember/no-component-lifecycle-hooks
-  willDestroyElement() {
-    super.willDestroyElement(...arguments);
+  willDestroy() {
+    super.willDestroy(...arguments);
 
     this._cancelAnimation();
     cancel(this._delayedVisibilityToggle);
@@ -404,7 +412,6 @@ export default class AttachPopover extends Component {
       document.removeEventListener(eventType, this._hideListenersOnDocumentByEvent[eventType], this.useCapture);
       delete this._hideListenersOnDocumentByEvent[eventType];
     });
-
     if (!this._currentTarget) {
       return;
     }
@@ -417,12 +424,13 @@ export default class AttachPopover extends Component {
       });
   }
 
-  @observes('hideOn', 'showOn', 'explicitTarget')
+  @action
   _targetOrTriggersChanged() {
+    console.log('_targetOrTriggersChanged!')
     this._initializeAttacher();
   }
 
-  @observes('isShown')
+  @action
   _isShownChanged() {
     const isShown = this.isShown;
 
@@ -444,7 +452,7 @@ export default class AttachPopover extends Component {
   _showAfterDelay() {
     cancel(this._delayedVisibilityToggle);
 
-    this.set('_mustRender', true);
+    this._mustRender = true;
 
     this._addListenersForHideEvents();
 
@@ -460,7 +468,7 @@ export default class AttachPopover extends Component {
       return;
     }
 
-    this.set('_mustRender', true);
+    this._mustRender = true;
 
     // Make the attachment visible immediately so transition animations can take place
     this._setIsVisibleAfterDelay(true, 0);
@@ -503,8 +511,8 @@ export default class AttachPopover extends Component {
           }
           // Make the floating element visible now that it has been positioned
           floatingElement.style.visibility = '';
-          this.set('_transitionDuration', parseInt(this.showDuration));
-          this.set('_isStartingAnimation', true);
+          this._transitionDuration = parseInt(this.showDuration);
+          this._isStartingAnimation = true;
           floatingElement.setAttribute('aria-hidden', 'false');
         });
 
@@ -554,8 +562,8 @@ export default class AttachPopover extends Component {
           return;
         }
 
-        this.set('_transitionDuration', hideDuration);
-        this.set('_isStartingAnimation', false);
+        this._transitionDuration = hideDuration;
+        this._isStartingAnimation = false;
         this._floatingElement.setAttribute('aria-hidden', 'true');
         // Wait for any animations to complete before hiding the attachment
         this._setIsVisibleAfterDelay(false, hideDuration);
@@ -789,7 +797,7 @@ export default class AttachPopover extends Component {
 
   @action
   didInsertArrow(element) {
-    this.set('_arrowElement', element);
+    this._arrowElement = element;
   }
 
   @action

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -118,7 +118,7 @@ export default class AttachPopover extends Component {
   }
 
   get renderFloatingElement() {
-    return this._currentTarget && (!this.lazyRender || this._mustRender)
+    return (this.renderInPlace || this._currentTarget) && (!this.lazyRender || this._mustRender);
   }
 
   get id() {
@@ -303,7 +303,6 @@ export default class AttachPopover extends Component {
   }
 
 
-
   constructor() {
     super(...arguments);
 
@@ -392,7 +391,7 @@ export default class AttachPopover extends Component {
   }
 
   @action
-  onTargetOrTriggerChanged() {
+  onTargetOrTriggerChange() {
     this._initializeAttacher();
   }
 
@@ -759,6 +758,11 @@ export default class AttachPopover extends Component {
   @action
   didInsertFloatingElement(floatingElement) {
     this._floatingElement = floatingElement;
+
+    if (this.renderInPlace) {
+      this.parentElement = floatingElement.parentElement;
+      this._initializeAttacher();
+    }
   }
 
   @action

--- a/addon/components/attach-tooltip.js
+++ b/addon/components/attach-tooltip.js
@@ -21,7 +21,7 @@ class AttachTooltip extends AttachPopover {
   }
 
   @action
-  explicitTargetChanged() {
+  onExplicitTargetChange() {
     const oldTarget = this._currentTarget;
     if (oldTarget) {
       oldTarget.removeAttribute('aria-describedby');

--- a/addon/components/attach-tooltip.js
+++ b/addon/components/attach-tooltip.js
@@ -1,4 +1,3 @@
-import { action } from '@ember/object';
 import AttachPopover from './attach-popover';
 import DEFAULTS from '../defaults';
 import layout from '../templates/components/attach-popover';
@@ -17,17 +16,13 @@ class AttachTooltip extends AttachPopover {
 
   _initializeAttacher() {
     super._initializeAttacher();
-    this._currentTarget?.setAttribute('aria-describedby', this.id);
-  }
 
-  @action
-  onExplicitTargetChange() {
-    const oldTarget = this._currentTarget;
-    if (oldTarget) {
-      oldTarget.removeAttribute('aria-describedby');
+    if (this._currentTarget?.getAttribute('aria-describedby') != this.id) {
+      const oldTarget = document.querySelector(`[aria-describedby="${this.id}"]`);
+
+      oldTarget?.removeAttribute('aria-describedby')
+      this._currentTarget?.setAttribute('aria-describedby', this.id);
     }
-
-    this.explicitTarget?.setAttribute('aria-describedby', this.id);
   }
 
   willDestroy() {

--- a/addon/components/attach-tooltip.js
+++ b/addon/components/attach-tooltip.js
@@ -1,17 +1,18 @@
-import classic from 'ember-classic-decorator';
-import { observes } from '@ember-decorators/object';
-import { computed } from '@ember/object';
+import { action } from '@ember/object';
 import AttachPopover from './attach-popover';
 import DEFAULTS from '../defaults';
+import layout from '../templates/components/attach-popover';
+import { setComponentTemplate } from '@ember/component';
 
-@classic
-export default class AttachTooltip extends AttachPopover {
+class AttachTooltip extends AttachPopover {
   configKey = 'tooltip';
-  ariaRole = 'tooltip';
 
-  @computed('_config.tooltipClass')
+  get ariaRole() {
+    return this.args.ariaRole || 'tooltip';
+  }
+
   get class() {
-    return this._config.tooltipClass || DEFAULTS.tooltipClass;
+    return `${this._config.tooltipClass || DEFAULTS.tooltipClass} ${this.args.class}`;
   }
 
   set class(value) {
@@ -20,31 +21,23 @@ export default class AttachTooltip extends AttachPopover {
     // eslint-disable-next-line no-setter-return
     return `${tooltipClass} ${value}`;
   }
-
-  didInsertElement() {
-    super.didInsertElement(...arguments);
-
-    if (!this._currentTarget) {
-      return;
-    }
-
-    this._currentTarget.setAttribute('aria-describedby', this.id);
+  _initializeAttacher() {
+    super._initializeAttacher();
+    this._currentTarget?.setAttribute('aria-describedby', this.id);
   }
 
-  @observes('explicitTarget')
+  @action
   explicitTargetChanged() {
     const oldTarget = this._currentTarget;
     if (oldTarget) {
       oldTarget.removeAttribute('aria-describedby');
     }
 
-    super.explicitTargetChanged;
-
-    this.explicitTarget.setAttribute('aria-describedby', this.id);
+    this.explicitTarget?.setAttribute('aria-describedby', this.id);
   }
 
-  willDestroyElement() {
-    super.willDestroyElement(...arguments);
+  willDestroy() {
+    super.willDestroy(...arguments);
 
     const target = this._currentTarget;
     if (target) {
@@ -52,3 +45,5 @@ export default class AttachTooltip extends AttachPopover {
     }
   }
 }
+
+export default setComponentTemplate(layout, AttachTooltip);

--- a/addon/components/attach-tooltip.js
+++ b/addon/components/attach-tooltip.js
@@ -11,16 +11,10 @@ class AttachTooltip extends AttachPopover {
     return this.args.ariaRole || 'tooltip';
   }
 
-  get class() {
-    return `${this._config.tooltipClass || DEFAULTS.tooltipClass} ${this.args.class}`;
+  get _class() {
+    return `${super._class} ${this._config.tooltipClass || DEFAULTS.tooltipClass}`
   }
 
-  set class(value) {
-    const tooltipClass = this._config.tooltipClass || DEFAULTS.tooltipClass;
-
-    // eslint-disable-next-line no-setter-return
-    return `${tooltipClass} ${value}`;
-  }
   _initializeAttacher() {
     super._initializeAttacher();
     this._currentTarget?.setAttribute('aria-describedby', this.id);

--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -1,4 +1,6 @@
-{{unbound this._parentFinder}}
+{{#unless this.parentElement}}
+  <div {{did-insert this.onParentFinderInsert}} />
+{{/unless}}
 
 {{~#if (and this._currentTarget (or (not this.lazyRender) this._mustRender))}}
   {{#in-element this._floatingElementContainer insertBefore=null}}
@@ -7,6 +9,9 @@
       id={{this.id}}
       role={{this.ariaRole}}
       {{did-insert this.didInsertFloatingElement}}
+      {{did-update this._isShownChanged this.isShown}}
+      {{did-update this.explicitTargetChanged @explicitTarget}}
+      {{did-update this._ensureArgumentsAreValid this.animation this.arrow this.useCapture}}
       {{did-update this.didUpdateOptions this.autoUpdate this.placement this._renderInPlace this._currentTarget this._middleware}}
       {{will-destroy this.willDestroyFloatingElement}}
       ...attributes

--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -3,14 +3,14 @@
 {{~/unless~}}
 
 {{~#if this.renderFloatingElement}}
-  {{#in-element this._floatingElementContainer insertBefore=null}}
+  {{~#maybe-in-element destinationElement=this._floatingElementContainer renderInPlace=@renderInPlace}}
     <div
       class="ember-attacher"
       id={{this.id}}
       role={{this.ariaRole}}
       {{did-insert this.didInsertFloatingElement}}
       {{did-update this.onIsShownChange this.isShown}}
-      {{did-update this.onTargetOrTriggerChanged this.hideOn this.showOn @explicitTarget}}
+      {{did-update this.onTargetOrTriggerChange this.hideOn this.showOn @explicitTarget}}
       {{did-update this.onOptionsChange this.autoUpdate this.animation this.arrow this.useCapture this.placement this._renderInPlace this._currentTarget this._middleware}}
       {{will-destroy this.willDestroyFloatingElement}}
       ...attributes
@@ -25,5 +25,5 @@
         {{/if}}
       </div>
     </div>
-  {{/in-element}}
+  {{~/maybe-in-element}}
 {{~/if~}}

--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -10,7 +10,7 @@
       role={{this.ariaRole}}
       {{did-insert this.didInsertFloatingElement}}
       {{did-update this.onIsShownChange this.isShown}}
-      {{did-update this.onExplicitTargetChange @explicitTarget}}
+      {{did-update this.onTargetOrTriggerChanged this.hideOn this.showOn @explicitTarget}}
       {{did-update this.onOptionsChange this.autoUpdate this.animation this.arrow this.useCapture this.placement this._renderInPlace this._currentTarget this._middleware}}
       {{will-destroy this.willDestroyFloatingElement}}
       ...attributes

--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -1,8 +1,8 @@
-{{#unless this.parentElement}}
-  <div {{did-insert this.onParentFinderInsert}} />
-{{/unless}}
+{{~#unless this.renderFloatingElement}}
+  <wbr hidden {{did-insert this.onParentFinderInsert}} {{did-update this._isShownChanged this.isShown}}/>
+{{~/unless~}}
 
-{{~#if (and this._currentTarget (or (not this.lazyRender) this._mustRender))}}
+{{~#if this.renderFloatingElement}}
   {{#in-element this._floatingElementContainer insertBefore=null}}
     <div
       class="ember-attacher"
@@ -12,7 +12,8 @@
       {{did-update this._isShownChanged this.isShown}}
       {{did-update this.explicitTargetChanged @explicitTarget}}
       {{did-update this._ensureArgumentsAreValid this.animation this.arrow this.useCapture}}
-      {{did-update this.didUpdateOptions this.autoUpdate this.placement this._renderInPlace this._currentTarget this._middleware}}
+      {{did-update this.didUpdateOptions this.autoUpdate this.placement this._renderInPlace this._currentTarget
+                   this._middleware}}
       {{will-destroy this.willDestroyFloatingElement}}
       ...attributes
     >

--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -1,5 +1,5 @@
 {{~#unless this.renderFloatingElement}}
-  <wbr hidden {{did-insert this.onParentFinderInsert}} {{did-update this._isShownChanged this.isShown}}/>
+  <wbr hidden {{did-insert this.onParentFinderInsert}} {{did-update this.onIsShownChange this.isShown}}/>
 {{~/unless~}}
 
 {{~#if this.renderFloatingElement}}
@@ -9,11 +9,9 @@
       id={{this.id}}
       role={{this.ariaRole}}
       {{did-insert this.didInsertFloatingElement}}
-      {{did-update this._isShownChanged this.isShown}}
-      {{did-update this.explicitTargetChanged @explicitTarget}}
-      {{did-update this._ensureArgumentsAreValid this.animation this.arrow this.useCapture}}
-      {{did-update this.didUpdateOptions this.autoUpdate this.placement this._renderInPlace this._currentTarget
-                   this._middleware}}
+      {{did-update this.onIsShownChange this.isShown}}
+      {{did-update this.onExplicitTargetChange @explicitTarget}}
+      {{did-update this.onOptionsChange this.autoUpdate this.animation this.arrow this.useCapture this.placement this._renderInPlace this._currentTarget this._middleware}}
       {{will-destroy this.willDestroyFloatingElement}}
       ...attributes
     >

--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -1,5 +1,5 @@
 {{~#unless this.renderFloatingElement}}
-  <wbr hidden {{did-insert this.onParentFinderInsert}} {{did-update this.onIsShownChange this.isShown}}/>
+  <meta {{did-insert this.onParentFinderInsert}} {{did-update this.onIsShownChange this.isShown}}/>
 {{~/unless~}}
 
 {{~#if this.renderFloatingElement}}

--- a/addon/templates/components/attach-popover.hbs
+++ b/addon/templates/components/attach-popover.hbs
@@ -1,5 +1,5 @@
 {{~#unless this.renderFloatingElement}}
-  <meta {{did-insert this.onParentFinderInsert}} {{did-update this.onIsShownChange this.isShown}}/>
+  <meta hidden {{did-insert this.onParentFinderInsert}} {{did-update this.onIsShownChange this.isShown}}/>
 {{~/unless~}}
 
 {{~#if this.renderFloatingElement}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,1 +1,0 @@
-@import "ember-power-select";

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,7 +12,8 @@ module.exports = async function() {
           devDependencies: {
             'ember-source': '~3.16.0',
             '@ember/render-modifiers': '^1.0.2',
-            'ember-qunit': '~5.1.5'
+            'ember-qunit': '~5.1.5',
+            'ember-maybe-in-element': '2.0.1'
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "~6.2.0",
     "ember-cli-sass": "~11.0.1",
-    "ember-in-element-polyfill": "~1.0.1"
+    "ember-in-element-polyfill": "~1.0.1",
+    "sass": "^1.62.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",
@@ -78,7 +79,6 @@
     "qunit": "~2.19.4",
     "qunit-dom": "~2.0.0",
     "release-it": "~15.10.1",
-    "sass": "^1.62.1",
     "webpack": "~5.82.1"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,9 @@
     "babel-plugin-filter-imports": "^4.0.0",
     "broccoli-funnel": "~3.0.8",
     "ember-auto-import": "~2.6.3",
-    "ember-classic-decorator": "~3.0.1",
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "~6.2.0",
     "ember-cli-sass": "~11.0.1",
-    "ember-decorators": "^6.1.1",
     "ember-in-element-polyfill": "~1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-attacher",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "Tooltips and popovers for Ember.js apps",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/core": "^7.21.4",
     "@babel/eslint-parser": "^7.21.8",
     "@ember/optional-features": "^2.0.0",
+    "@ember/render-modifiers": "^2.0.5",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "~2.9.3",
     "@ember/test-waiters": "^3.0.2",
@@ -60,7 +61,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^1.0.0",
-    "ember-power-select": "~5.0.4",
+    "ember-maybe-in-element": "^2.1.0",
     "ember-qunit": "^6.2.0",
     "ember-resolver": "~10.0.0",
     "ember-source": "~3.28.11",
@@ -81,8 +82,7 @@
     "webpack": "~5.82.1"
   },
   "resolutions": {
-    "ember-in-element-polyfill": "^1.0.1",
-    "ember-maybe-in-element": "2.0.1"
+    "ember-in-element-polyfill": "^1.0.1"
   },
   "engines": {
     "node": ">= 12.*"

--- a/tests/dummy/app/components/attachment-example.js
+++ b/tests/dummy/app/components/attachment-example.js
@@ -67,4 +67,24 @@ export default class AttachmentExample extends Component {
   setIsConfiguringTooltip(bool) {
     this.isConfiguringTooltip = bool;
   }
+
+  @action
+  updateAnimation({ target }) {
+    this.service.set('animation', target.value);
+  }
+
+  @action
+  updateHideOn({ target }) {
+    this.service.set('hideOn', target.value);
+  }
+
+  @action
+  updatePlacement({ target }) {
+    this.service.set('placement', target.value);
+  }
+
+  @action
+  updateShowOn({ target }) {
+    this.service.set('showOn', target.value);
+  }
 }

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,5 +1,3 @@
-@import 'ember-power-select';
-
 body {
   color: #fcfcfc;
   font-family: helvetica;
@@ -188,10 +186,6 @@ p {
 
 .underlined {
   border-bottom: 2px dotted #999;
-}
-
-.ember-power-select-option {
-  color: #111;
 }
 
 @media (max-width: 400px) {

--- a/tests/dummy/app/templates/components/attachment-example.hbs
+++ b/tests/dummy/app/templates/components/attachment-example.hbs
@@ -1,5 +1,8 @@
 <div data-element-centered class="section top-section">
-  <p>Drop an <span class="no-wrap">\{{#attach-tooltip}}</span> or <span class="no-wrap">\{{#attach-popover}}</span> in any element or component to get started.</p>
+  <p>
+    Drop an <span class="no-wrap"><code>&lt;AttachTooltip&gt;</code></span>
+    or <span class="no-wrap"><code>&lt;AttachPopover&gt;</code></span> in any element or component to get started.
+  </p>
 </div>
 <div data-element-centered class="section">
   <div data-element-centered class="floating-area justify-around col-lg-10 col-md-12 col-sm-16 col-lm-20 col-xs-24">
@@ -72,10 +75,10 @@
   <div data-element-vbox class="fit-lm">
     <div data-element-hbox class="nav-bar">
       <div data-element-centered class="col-xs-12 nav{{if this.isConfiguringTooltip ' active'}}" {{action 'setIsConfiguringTooltip' true}}>
-        \{{#attach-tooltip}}
+        <code>&lt;AttachTooltip&gt;</code>
       </div>
       <div data-element-centered  class="col-xs-12 nav{{unless this.isConfiguringTooltip ' active'}}" {{action 'setIsConfiguringTooltip' false}}>
-        \{{#attach-popover}}
+        <code>&lt;AttachPopover&gt;</code>
       </div>
     </div>
 
@@ -91,18 +94,18 @@
     <div data-element-box class="flexi-fit horizontal-lm">
       <div data-element-hbox class="no-wrap flexi-fit">
         <div data-element-centered class="flexi-fit">
-          &nbsp;&nbsp;\{{
+          &nbsp;&nbsp;&lt;
           <span class="underlined">
-            {{if this.isConfiguringTooltip '#attach-tooltip' '#attach-popover'}}
+            {{if this.isConfiguringTooltip 'AttachTooltip' 'AttachPopover'}}
 
             {{#attach-tooltip animation='shift'}}
               {{#if this.isConfiguringTooltip}}
-                This component has the default settings. The \{{attach-tooltip}} component
+                This component has the default settings. The &lt;AttachTooltip&gt; component
                 automatically gains the ember-attacher-floating and ember-attacher-tooltip classes.
                 It also modifies the target element's aria-describedby to point to the tooltip.
-                For manual control, use \{{attach-popover}} instead.
+                For manual control, use &lt;AttachPopover&gt; instead.
               {{else}}
-                This is a click-triggered \{{attach-popover}}. Unlike \{{attach-tooltip}}, it does
+                This is a click-triggered &lt;AttachPopover&gt;. Unlike &lt;AttachTooltip&gt;, it does
                 not modify the target's aria-describedby, or have any default classes.
               {{/if}}
             {{/attach-tooltip}}
@@ -113,7 +116,7 @@
       <div data-element-hbox class="flexi-fit">
         <div data-element-box class="hidden-lm fit-xs">&nbsp;&nbsp;&nbsp;&nbsp;</div>
         <div data-element-centered class="flexi-fit">
-          animation="<PowerSelect
+          @animation="<PowerSelect
                       @onChange={{action (mut this.service.animation)}}
                       @options={{this.animationOptions}}
                       @searchEnabled={{false}}
@@ -128,13 +131,13 @@
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        arrow=<button class="button medium" {{action "toggleArrow"}}>{{this.service.arrow}}</button>
+        @arrow=<button class="button medium" {{action "toggleArrow"}}>{{this.service.arrow}}</button>
       </div>
     </div>
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        hideDelay={{input class="button medium"
+        @hideDelay={{input class="button medium"
                           min="0"
                           pattern="[0-9]"
                           placeholder="0"
@@ -147,7 +150,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          hideDuration
+          @hideDuration
 
           {{#attach-tooltip}}
             How long the hide animation will take.
@@ -166,7 +169,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          hideOn
+          @hideOn
 
           {{#attach-tooltip animation='shift'}}
             Any combination of "blur", "click", "clickout", "escapekey", and "mouseleave".
@@ -189,7 +192,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          interactive
+          @interactive
 
           {{#attach-tooltip}}
             Interactive tooltips will not close when clicked or hovered over.
@@ -205,7 +208,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          isShown
+          @isShown
 
           {{#attach-tooltip}}
             Manually controls whether or not the attacher should be open or closed.
@@ -220,7 +223,7 @@
       <div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          lazyRender
+          @lazyRender
 
           {{#attach-tooltip}}
             If you want ember-attacher to postpone rendering until first interacted.
@@ -234,7 +237,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          onChange
+          @onChange
 
           {{#attach-tooltip}}
             An action to be fired when the attachment's visibility changes.
@@ -246,7 +249,7 @@
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        placement="<PowerSelect
+        @placement="<PowerSelect
                     @onChange={{action (mut this.service.placement)}}
                     @options={{placementOptions}}
                     @searchEnabled={{false}}
@@ -261,7 +264,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          autoUpdate
+          @autoUpdate
 
           {{#attach-tooltip animation='shift'}}
             The floating element can detach from the reference element if the user scrolls or resizes the screen, so its position needs to be updated again to ensure it stays anchored.
@@ -278,7 +281,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          renderInPlace
+          @renderInPlace
 
           {{#attach-tooltip animation="shift"}}
             Elements that exist deep within the document tree are given an implicitly lower z-index
@@ -299,7 +302,7 @@
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        showDelay={{input class="button medium"
+        @showDelay={{input class="button medium"
                           min="0"
                           pattern="[0-9]"
                           placeholder="0"
@@ -312,7 +315,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          showDuration
+          @showDuration
 
           {{#attach-tooltip}}
             How long the show animation will take.
@@ -331,7 +334,7 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <span class="underlined">
-          showOn
+          @showOn
 
           {{#attach-tooltip}}
             For performance reasons, we recommend using some combination of "mouseenter", "focus",
@@ -353,23 +356,23 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         <vbox>
-          {{#if isConfiguringTooltip}}
+          {{#if this.isConfiguringTooltip}}
             <div data-element-hbox>
               <div data-element-centered class="flexi-fit">
                 <span class="underlined">
-                  class
+                  @class
 
-                  {{#attach-tooltip}}
-                    The \{{attach-tooltip}} component automatically adds
+                  <AttachTooltip>
+                    The &lt;AttachTooltip&gt; component automatically adds
                     ember-attacher-floating and ember-attacher-tooltip to the class string.
-                  {{/attach-tooltip}}
+                  </AttachTooltip>
                 </span>
-                ='optional-class-here'}}
+                ='optional-class-here'&gt;
               </div>
             </div>
           {{else}}
             <div data-element-hbox><div data-element-centered class="flexi-fit">class="ember-attacher-floating custom-popover-css"</div></div>
-            <div data-element-hbox><div data-element-centered class="flexi-fit">as |attacher|}}</div></div>
+            <div data-element-hbox><div data-element-centered class="flexi-fit">as |attacher|&gt;</div></div>
           {{/if}}
         </vbox>
       </div>
@@ -404,7 +407,7 @@
       </div>
     {{/if}}
     <div data-element-hbox>
-      &nbsp;&nbsp;\{{/{{if this.isConfiguringTooltip 'attach-tooltip}}' 'attach-popover}}'}}
+      &nbsp;&nbsp;&lt;\\{{if this.isConfiguringTooltip 'AttachTooltip' 'AttachPopover'}}&gt;
     </div>
     <div data-element-hbox>
       <div data-element-centered class="flexi-fit">&lt;\button></div>

--- a/tests/dummy/app/templates/components/attachment-example.hbs
+++ b/tests/dummy/app/templates/components/attachment-example.hbs
@@ -7,20 +7,20 @@
       Tooltip me, captain!
 
       <AttachTooltip
-        @animation={{tooltipData.animation}}
-        @arrow={{tooltipData.arrow}}
-        @autoUpdate={{tooltipData.autoUpdate}}
-        @hideDelay={{tooltipData.hideDelay}}
-        @hideDuration={{tooltipData.hideDuration}}
-        @hideOn={{tooltipData.hideOn}}
-        @interactive={{tooltipData.interactive}}
-        @isShown={{tooltipData.isShown}}
-        @onChange={{action (mut tooltipData.isShown)}}
-        @placement={{tooltipData.placement}}
-        @renderInPlace={{tooltipData.renderInPlace}}
-        @showDelay={{tooltipData.showDelay}}
-        @showDuration={{tooltipData.showDuration}}
-        @showOn={{tooltipData.showOn}}
+        @animation={{this.tooltipData.animation}}
+        @arrow={{this.tooltipData.arrow}}
+        @autoUpdate={{this.tooltipData.autoUpdate}}
+        @hideDelay={{this.tooltipData.hideDelay}}
+        @hideDuration={{this.tooltipData.hideDuration}}
+        @hideOn={{this.tooltipData.hideOn}}
+        @interactive={{this.tooltipData.interactive}}
+        @isShown={{this.tooltipData.isShown}}
+        @onChange={{action (mut this.tooltipData.isShown)}}
+        @placement={{this.tooltipData.placement}}
+        @renderInPlace={{this.tooltipData.renderInPlace}}
+        @showDelay={{this.tooltipData.showDelay}}
+        @showDuration={{this.tooltipData.showDuration}}
+        @showOn={{this.tooltipData.showOn}}
         data-test-demo-tooltip
       >
         Hello world!
@@ -31,22 +31,22 @@
       Click me, captain!
 
       <AttachPopover
-        @animation={{popoverData.animation}}
-        @arrow={{popoverData.arrow}}
-        @autoUpdate={{popoverData.autoUpdate}}
+        @animation={{this.popoverData.animation}}
+        @arrow={{this.popoverData.arrow}}
+        @autoUpdate={{this.popoverData.autoUpdate}}
         @class="ember-attacher-popover custom-popover-css"
-        @hideDelay={{popoverData.hideDelay}}
-        @hideDuration={{popoverData.hideDuration}}
-        @hideOn={{popoverData.hideOn}}
-        @interactive={{popoverData.interactive}}
-        @isShown={{popoverData.isShown}}
-        @lazyRender={{popoverData.lazyRender}}
-        @onChange={{action (mut popoverData.isShown)}}
-        @placement={{popoverData.placement}}
-        @renderInPlace={{popoverData.renderInPlace}}
-        @showDelay={{popoverData.showDelay}}
-        @showDuration={{popoverData.showDuration}}
-        @showOn={{popoverData.showOn}}
+        @hideDelay={{this.popoverData.hideDelay}}
+        @hideDuration={{this.popoverData.hideDuration}}
+        @hideOn={{this.popoverData.hideOn}}
+        @interactive={{this.popoverData.interactive}}
+        @isShown={{this.popoverData.isShown}}
+        @lazyRender={{this.popoverData.lazyRender}}
+        @onChange={{action (mut this.popoverData.isShown)}}
+        @placement={{this.popoverData.placement}}
+        @renderInPlace={{this.popoverData.renderInPlace}}
+        @showDelay={{this.popoverData.showDelay}}
+        @showDuration={{this.popoverData.showDuration}}
+        @showOn={{this.popoverData.showOn}}
         data-test-demo-popover as |emberAttacher|
       >
         <p>Popovers and tooltips, oh my!</p>
@@ -56,13 +56,13 @@
     </button>
   </div>
 </div>
-{{#if (and service.arrow (eq service.animation "fill"))}}
+{{#if (and this.service.arrow (eq this.service.animation "fill"))}}
   <div data-element-centered class="section">
     <h2>Warning: `animation: "fill"` is not compatible with `arrow: true`</h2>
   </div>
 {{/if}}
 
-{{#if service.renderInPlace}}
+{{#if this.service.renderInPlace}}
   <div data-element-centered class="section flexi-fit flexi-vertical">
     <h3>Note: renderInPlace can cause z-index issues.</h3>
     <h3>Hover over the renderInPlace attr for more details.</h3>
@@ -114,10 +114,10 @@
         <div data-element-box class="hidden-lm fit-xs">&nbsp;&nbsp;&nbsp;&nbsp;</div>
         <div data-element-centered class="flexi-fit">
           animation="<PowerSelect
-                      @onChange={{action (mut service.animation)}}
-                      @options={{animationOptions}}
+                      @onChange={{action (mut this.service.animation)}}
+                      @options={{this.animationOptions}}
                       @searchEnabled={{false}}
-                      @selected={{service.animation}}
+                      @selected={{this.service.animation}}
                       @triggerClass="button large" as |animationOption|
                      >
                       {{animationOption}}
@@ -128,7 +128,7 @@
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        arrow=<button class="button medium" {{action "toggleArrow"}}>{{service.arrow}}</button>
+        arrow=<button class="button medium" {{action "toggleArrow"}}>{{this.service.arrow}}</button>
       </div>
     </div>
     <div data-element-hbox>
@@ -140,7 +140,7 @@
                           placeholder="0"
                           step="100"
                           type="number"
-                          value=service.hideDelay}}
+                          value=this.service.hideDelay}}
       </div>
     </div>
     <div data-element-hbox>
@@ -159,7 +159,7 @@
                  placeholder="0"
                  step="100"
                  type="number"
-                 value=service.hideDuration}}
+                 value=this.service.hideDuration}}
       </div>
     </div>
     <div data-element-hbox>
@@ -175,10 +175,10 @@
           {{/attach-tooltip}}
         </span>
         ="<PowerSelect
-            @onChange={{action (mut service.hideOn)}}
+            @onChange={{action (mut this.service.hideOn)}}
             @options={{hideOnOptions}}
             @searchEnabled={{false}}
-            @selected={{service.hideOn}}
+            @selected={{this.service.hideOn}}
             @triggerClass="button xlarge" as |hideOnOption|
           >
             {{hideOnOption}}
@@ -197,7 +197,7 @@
         </span>
         =
         <button class="button medium" {{action "toggleInteractive"}}>
-          {{service.interactive}}
+          {{this.service.interactive}}
         </button>
       </div>
     </div>
@@ -212,7 +212,7 @@
           {{/attach-tooltip}}
         </span>
         =
-        <button class="button medium" {{action "toggleIsShown"}}>{{service.isShown}}</button>
+        <button class="button medium" {{action "toggleIsShown"}}>{{this.service.isShown}}</button>
       </div>
     </div>
     <div data-element-hbox>
@@ -227,7 +227,7 @@
           {{/attach-tooltip}}
         </span>
         =
-        <button class="button medium" {{action "toggleLazyRender"}}>{{service.lazyRender}}</button>
+        <button class="button medium" {{action "toggleLazyRender"}}>{{this.service.lazyRender}}</button>
       </div>
     </div>
     <div data-element-hbox>
@@ -247,10 +247,10 @@
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
         placement="<PowerSelect
-                    @onChange={{action (mut service.placement)}}
+                    @onChange={{action (mut this.service.placement)}}
                     @options={{placementOptions}}
                     @searchEnabled={{false}}
-                    @selected={{service.placement}}
+                    @selected={{this.service.placement}}
                     @triggerClass="button large" as |placementOption|
                   >
                     {{placementOption}}
@@ -270,7 +270,7 @@
         </span>
         =
         <button class="button medium" {{action "toggleAutoUpdate"}}>
-          {{service.autoUpdate}}
+          {{this.service.autoUpdate}}
         </button>
       </div>
     </div>
@@ -292,7 +292,7 @@
         </span>
         =
         <button class="button medium" {{action "toggleRenderInPlace"}}>
-          {{service.renderInPlace}}
+          {{this.service.renderInPlace}}
         </button>
       </div>
     </div>
@@ -305,7 +305,7 @@
                           placeholder="0"
                           step="100"
                           type="number"
-                          value=service.showDelay}}
+                          value=this.service.showDelay}}
       </div>
     </div>
     <div data-element-hbox>
@@ -324,7 +324,7 @@
                  placeholder="0"
                  step="100"
                  type="number"
-                 value=service.showDuration}}
+                 value=this.service.showDuration}}
       </div>
     </div>
     <div data-element-hbox>
@@ -339,10 +339,10 @@
           {{/attach-tooltip}}
         </span>
         ="<PowerSelect
-            @onChange={{action (mut service.showOn)}}
+            @onChange={{action (mut this.service.showOn)}}
             @options={{showOnOptions}}
             @searchEnabled={{false}}
-            @selected={{service.showOn}}
+            @selected={{this.service.showOn}}
             @triggerClass="button xlarge" as |showOnOption|
           >
             {{showOnOption}}
@@ -374,7 +374,7 @@
         </vbox>
       </div>
     </div>
-    {{#if isConfiguringTooltip}}
+    {{#if this.isConfiguringTooltip}}
       <div data-element-hbox>&nbsp;&nbsp;&nbsp;&nbsp;Hello world!</div>
     {{else}}
       <div data-element-vbox>
@@ -404,7 +404,7 @@
       </div>
     {{/if}}
     <div data-element-hbox>
-      &nbsp;&nbsp;\{{/{{if isConfiguringTooltip 'attach-tooltip}}' 'attach-popover}}'}}
+      &nbsp;&nbsp;\{{/{{if this.isConfiguringTooltip 'attach-tooltip}}' 'attach-popover}}'}}
     </div>
     <div data-element-hbox>
       <div data-element-centered class="flexi-fit">&lt;\button></div>

--- a/tests/dummy/app/templates/components/attachment-example.hbs
+++ b/tests/dummy/app/templates/components/attachment-example.hbs
@@ -116,15 +116,15 @@
       <div data-element-hbox class="flexi-fit">
         <div data-element-box class="hidden-lm fit-xs">&nbsp;&nbsp;&nbsp;&nbsp;</div>
         <div data-element-centered class="flexi-fit">
-          @animation="<PowerSelect
-                      @onChange={{action (mut this.service.animation)}}
-                      @options={{this.animationOptions}}
-                      @searchEnabled={{false}}
-                      @selected={{this.service.animation}}
-                      @triggerClass="button large" as |animationOption|
-                     >
-                      {{animationOption}}
-                     </PowerSelect>"
+          @animation="
+          <select {{on "change" this.updateAnimation}} class="button large">
+            {{#each this.animationOptions as |animationOption|}}
+              <option selected={{eq this.service.animation animationOption}} value="{{animationOption}}">
+                {{animationOption}}
+              </option>
+            {{/each}}
+          </select>
+          "
         </div>
       </div>
     </div>
@@ -137,13 +137,13 @@
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        @hideDelay={{input class="button medium"
+        @hideDelay=<Input class="button medium"
                           min="0"
                           pattern="[0-9]"
                           placeholder="0"
                           step="100"
-                          type="number"
-                          value=this.service.hideDelay}}
+                          @type="number"
+                          @value={{this.service.hideDelay}} />
       </div>
     </div>
     <div data-element-hbox>
@@ -156,13 +156,13 @@
             How long the hide animation will take.
           {{/attach-tooltip}}
         </span>
-        ={{input class="button medium"
+        =<Input class="button medium"
                  min="0"
                  pattern="[0-9]"
                  placeholder="0"
                  step="100"
-                 type="number"
-                 value=this.service.hideDuration}}
+                 @type="number"
+                 @value={{this.service.hideDuration}} />
       </div>
     </div>
     <div data-element-hbox>
@@ -177,15 +177,14 @@
             <p>escapekey: hides the attachment when the user presses the escape key</p>
           {{/attach-tooltip}}
         </span>
-        ="<PowerSelect
-            @onChange={{action (mut this.service.hideOn)}}
-            @options={{hideOnOptions}}
-            @searchEnabled={{false}}
-            @selected={{this.service.hideOn}}
-            @triggerClass="button xlarge" as |hideOnOption|
-          >
-            {{hideOnOption}}
-          </PowerSelect>"
+        ="
+        <select {{on "change" this.updateHideOn}} class="button xlarge">
+          {{#each this.hideOnOptions as |hideOnOption|}}
+            <option selected={{eq this.service.hideOn hideOnOption}} value="{{hideOnOption}}">
+              {{hideOnOption}}
+            </option>
+          {{/each}}
+        </select>"
       </div>
     </div>
     <div data-element-hbox>
@@ -249,15 +248,14 @@
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        @placement="<PowerSelect
-                    @onChange={{action (mut this.service.placement)}}
-                    @options={{placementOptions}}
-                    @searchEnabled={{false}}
-                    @selected={{this.service.placement}}
-                    @triggerClass="button large" as |placementOption|
-                  >
-                    {{placementOption}}
-                  </PowerSelect>"
+        @placement="
+        <select {{on "change" this.updatePlacement}} class="button large">
+          {{#each this.placementOptions as |placementOption|}}
+            <option selected={{eq this.service.placement placementOption}} value="{{placementOption}}">
+              {{placementOption}}
+            </option>
+          {{/each}}
+        </select>"
       </div>
     </div>
     <div data-element-hbox>
@@ -302,13 +300,13 @@
     <div data-element-hbox>
       &nbsp;&nbsp;&nbsp;&nbsp;<div data-element-box class="flexi-fit horizontal-lm">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</div>
       <div data-element-centered class="flexi-fit">
-        @showDelay={{input class="button medium"
+        @showDelay=<Input class="button medium"
                           min="0"
                           pattern="[0-9]"
                           placeholder="0"
                           step="100"
-                          type="number"
-                          value=this.service.showDelay}}
+                          @type="number"
+                          @value={{this.service.showDelay}}/>
       </div>
     </div>
     <div data-element-hbox>
@@ -321,13 +319,13 @@
             How long the show animation will take.
           {{/attach-tooltip}}
         </span>
-        ={{input class="button medium"
+        =<Input class="button medium"
                  min="0"
                  pattern="[0-9]"
                  placeholder="0"
                  step="100"
-                 type="number"
-                 value=this.service.showDuration}}
+                 @type="number"
+                 @value={{this.service.showDuration}} />
       </div>
     </div>
     <div data-element-hbox>
@@ -341,15 +339,14 @@
             and "click", though you can use any event listener you want.
           {{/attach-tooltip}}
         </span>
-        ="<PowerSelect
-            @onChange={{action (mut this.service.showOn)}}
-            @options={{showOnOptions}}
-            @searchEnabled={{false}}
-            @selected={{this.service.showOn}}
-            @triggerClass="button xlarge" as |showOnOption|
-          >
-            {{showOnOption}}
-          </PowerSelect>"
+        ="
+        <select {{on "change" this.updateShowOn}} class="button large">
+          {{#each this.showOnOptions as |showOnOption|}}
+            <option selected={{eq this.service.showOn showOnOption}} value="{{showOnOption}}">
+              {{showOnOption}}
+            </option>
+          {{/each}}
+        </select>"
       </div>
     </div>
     <div data-element-hbox>

--- a/tests/integration/components/ember-attacher/ember-attacher-test.js
+++ b/tests/integration/components/ember-attacher/ember-attacher-test.js
@@ -1,16 +1,14 @@
 import { hbs } from 'ember-cli-htmlbars';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-
 import { render, find } from '@ember/test-helpers';
 
 module('Integration | Component | ember attacher', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it leaves no content', async function(assert) {
-    await render(hbs`
-      <div id='wrapper'>{{#attach-popover}}{{/attach-popover}}</div>
-    `);
+  // we need a hack to determine the attached element's parent element
+  skip('it leaves no content', async function(assert) {
+    await render(hbs`<div id='wrapper'><AttachPopover /></div>`);
 
     const wrapper = find('#wrapper');
 

--- a/tests/integration/components/ember-attacher/ember-attacher-test.js
+++ b/tests/integration/components/ember-attacher/ember-attacher-test.js
@@ -1,13 +1,12 @@
 import { hbs } from 'ember-cli-htmlbars';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 
 module('Integration | Component | ember attacher', function(hooks) {
   setupRenderingTest(hooks);
 
-  // we need a hack to determine the attached element's parent element
-  skip('it leaves no content', async function(assert) {
+  test('it leaves no content', async function(assert) {
     await render(hbs`<div id='wrapper'><AttachPopover /></div>`);
 
     const wrapper = find('#wrapper');

--- a/tests/integration/components/ember-attacher/explicit-target-test.js
+++ b/tests/integration/components/ember-attacher/explicit-target-test.js
@@ -1,0 +1,39 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find, focus, settled } from '@ember/test-helpers';
+import { isVisible } from 'ember-attacher';
+
+module('Integration | Component | explicit target', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it processes the explicit target change', async function (assert) {
+    this.set('explicitTarget', null);
+
+    await render(hbs`
+      <div>
+        <button id="new-target" />
+        <button id="old-target">
+          <AttachTooltip @id="attachment" @explicitTarget={{this.explicitTarget}} @showOn="focus">
+            Floating element
+          </AttachTooltip>
+        </button>
+      </div>
+    `);
+
+    assert.dom('#old-target').hasAria('describedby', 'attachment');
+    await focus('#old-target');
+    const attachment = find('#attachment');
+    assert.equal(isVisible(attachment), true, 'Is shown on focus');
+    await focus('#new-target');
+    assert.equal(isVisible(attachment), false, 'Hides after focusing on another target');
+    this.set('explicitTarget', find('#new-target'));
+    await settled();
+    await focus('#old-target');
+    assert.equal(isVisible(attachment), false, 'Not showing on old target focus');
+    await focus('#new-target');
+    assert.equal(isVisible(attachment), true, 'Is shown on new target focus');
+    assert.dom('#old-target').doesNotHaveAria('describedby');
+    assert.dom('#new-target').hasAria('describedby', 'attachment');
+  });
+});

--- a/tests/integration/components/ember-attacher/is-shown-test.js
+++ b/tests/integration/components/ember-attacher/is-shown-test.js
@@ -127,7 +127,7 @@ module('Integration | Component | isShown', function(hooks) {
 
     await click('#open');
 
-    const attachment = find('#attachment');
+    const attachment = await waitFor('#attachment');
 
     await settled();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1989,23 +1989,7 @@
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-decorators/component@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-6.1.1.tgz#b360dc4fa8e576ee1c840879399ef1745fd96e06"
-  integrity sha512-Cj8tY/c0MC/rsipqsiWLh3YVN72DK92edPYamD/HzvftwzC6oDwawWk8RmStiBnG9PG/vntAt41l3S7HSSA+1Q==
-  dependencies:
-    "@ember-decorators/utils" "^6.1.1"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/object@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-6.1.1.tgz#50c922f5ac9af3ddd381cb6a43a031dfd9a70c7a"
-  integrity sha512-cb4CNR9sRoA31J3FCOFLDuR9ztM4wO9w1WlS4JeNRS7Z69SlB/XSXB/vplA3i9OOaXEy/zKWbu5ndZrHz0gvLw==
-  dependencies:
-    "@ember-decorators/utils" "^6.1.1"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/utils@^6.1.0", "@ember-decorators/utils@^6.1.1":
+"@ember-decorators/utils@^6.1.0":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-6.1.1.tgz#6b619814942b4fb3747cfa9f540c9f05283d7c5e"
   integrity sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==
@@ -5584,16 +5568,6 @@ ember-auto-import@^2.6.0, ember-auto-import@~2.6.3:
     ember-style-modifier "^0.7.0"
     ember-truth-helpers "^2.1.0 || ^3.0.0"
 
-ember-classic-decorator@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-classic-decorator/-/ember-classic-decorator-3.0.1.tgz#13acf53e5fdb1f867919765853eb3592380ed1ef"
-  integrity sha512-IoocHPX1cY93Sma7VeDGbF0M1+TkBWDJLus+RD01902eD+KHEL2+diwM+iayCyO+1/xaUzdzNGh35J+i+TCxoA==
-  dependencies:
-    "@embroider/macros" "^1.0.0"
-    babel-plugin-filter-imports "^4.0.0"
-    ember-cli-babel "^7.26.11"
-    ember-cli-htmlbars "^6.0.1"
-
 ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, ember-cli-babel-plugin-helpers@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
@@ -6124,15 +6098,6 @@ ember-concurrency-decorators@^2.0.0:
     ember-cli-htmlbars "^5.7.1"
     ember-compatibility-helpers "^1.2.0"
     ember-destroyable-polyfill "^2.0.2"
-
-ember-decorators@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-6.1.1.tgz#6d770f8999cf5a413a1ee459afd520838c0fc470"
-  integrity sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==
-  dependencies:
-    "@ember-decorators/component" "^6.1.1"
-    "@ember-decorators/object" "^6.1.1"
-    ember-cli-babel "^7.7.3"
 
 ember-destroyable-polyfill@^2.0.2, ember-destroyable-polyfill@^2.0.3:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,7 +209,7 @@
     "@babel/helper-replace-supers" "^7.14.3"
     "@babel/helper-split-export-declaration" "^7.12.13"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.5.5", "@babel/helper-create-class-features-plugin@^7.8.3":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.21.0", "@babel/helper-create-class-features-plugin@^7.5.5":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.4.tgz#3a017163dc3c2ba7deb9a7950849a9586ea24c18"
   integrity sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==
@@ -842,7 +842,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.18.6", "@babel/plugin-proposal-nullish-coalescing-operator@^7.4.4":
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz#fdd940a99a740e577d6c753ab6fbb43fdb9467e1"
   integrity sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==
@@ -911,7 +911,7 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.20.7", "@babel/plugin-proposal-optional-chaining@^7.21.0", "@babel/plugin-proposal-optional-chaining@^7.6.0":
+"@babel/plugin-proposal-optional-chaining@^7.20.7", "@babel/plugin-proposal-optional-chaining@^7.21.0":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz#886f5c8978deb7d30f678b2e24346b287234d3ea"
   integrity sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==
@@ -1108,13 +1108,6 @@
   integrity sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-
-"@babel/plugin-syntax-typescript@^7.8.3":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.21.4.tgz#2751948e9b7c6d771a8efa59340c15d4a2891ff8"
-  integrity sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.20.2"
 
 "@babel/plugin-transform-arrow-functions@^7.12.1":
   version "7.12.1"
@@ -1632,15 +1625,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
-"@babel/plugin-transform-typescript@~7.8.0":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz#48bccff331108a7b3a28c3a4adc89e036dc3efda"
-  integrity sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.8.3"
-    "@babel/helper-plugin-utils" "^7.8.3"
-    "@babel/plugin-syntax-typescript" "^7.8.3"
-
 "@babel/plugin-transform-unicode-escapes@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz#5232b9f81ccb07070b7c3c36c67a1b78f1845709"
@@ -1989,13 +1973,6 @@
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-decorators/utils@^6.1.0":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-6.1.1.tgz#6b619814942b4fb3747cfa9f540c9f05283d7c5e"
-  integrity sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==
-  dependencies:
-    ember-cli-babel "^7.1.3"
-
 "@ember/edition-utils@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.2.0.tgz#a039f542dc14c8e8299c81cd5abba95e2459cfa6"
@@ -2013,7 +1990,7 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/render-modifiers@^2.0.4":
+"@ember/render-modifiers@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-2.0.5.tgz#4b1d9496a82ca471aeaa3ecddd94ef089450f415"
   integrity sha512-5cJ1niIdOJC6k6KtIn9HGbr1DATJQp4ZqMv1vbi6LKQWbVCQ3byvKONtUEi3H0wcewlrcaWCqXOgm0nACzCOQA==
@@ -2053,19 +2030,7 @@
     ember-cli-version-checker "^5.1.2"
     semver "^7.3.5"
 
-"@embroider/macros@0.40.0":
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.40.0.tgz#f58763b4cfb9b4089679b478a28627595341bc5a"
-  integrity sha512-ygChvFoebSi/N8b+A+XFncd454gLYBYHancrtY0AE/h6Y1HouoqQvji/IfaLisGoeuwUWuI9rCBv97COweu/rA==
-  dependencies:
-    "@embroider/shared-internals" "0.40.0"
-    assert-never "^1.1.0"
-    ember-cli-babel "^7.23.0"
-    lodash "^4.17.10"
-    resolve "^1.8.1"
-    semver "^7.3.2"
-
-"@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.2.0":
+"@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.10.0.tgz#af3844d5db48f001b85cfb096c76727c72ad6c1e"
   integrity sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==
@@ -2078,19 +2043,6 @@
     lodash "^4.17.21"
     resolve "^1.20.0"
     semver "^7.3.2"
-
-"@embroider/shared-internals@0.40.0":
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-0.40.0.tgz#2f768c60f4f35ba5f9228f046f70324851e8bfe2"
-  integrity sha512-Ovr/i0Qgn6W6jdGXMvYJKlRoRpyBY9uhYozDSFKlBjeEmRJ0Plp7OST41+O5Td6Pqp+Rv2jVSnGzhA/MpC++NQ==
-  dependencies:
-    ember-rfc176-data "^0.3.17"
-    fs-extra "^7.0.1"
-    lodash "^4.17.10"
-    pkg-up "^3.1.0"
-    resolve-package-path "^1.2.2"
-    semver "^7.3.2"
-    typescript-memoize "^1.0.0-alpha.3"
 
 "@embroider/shared-internals@2.0.0", "@embroider/shared-internals@^2.0.0":
   version "2.0.0"
@@ -2106,16 +2058,7 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0":
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/@embroider/util/-/util-0.40.0.tgz#437df92cd816405ae5b511bca7237db5a0126da0"
-  integrity sha512-S/UOY0s0+ZzeQTBAJ1BB42LjCYqxt6Fo+Q7nGCUt1SGtSOpFV+l6q0oNQyOeVTZwj0A+WdYe32EZPlbholfrWg==
-  dependencies:
-    "@embroider/macros" "0.40.0"
-    broccoli-funnel ef4/broccoli-funnel#c70d060076e14793e8495571f304a976afc754ac
-    ember-cli-babel "^7.23.1"
-
-"@embroider/util@^1.0.0", "@embroider/util@^1.2.0", "@embroider/util@^1.9.0":
+"@embroider/util@^1.9.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.10.0.tgz#8320d73651e7f5d48dac1b71fb9e6d21cac7c803"
   integrity sha512-utAFKoq6ajI27jyqjvX3PiGL4m+ZyGVlVNbSbE/nOqi2llRyAkh5ltH1WkIK7jhdwQFJouo1NpOSj9J3/HDa3A==
@@ -2173,7 +2116,7 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@glimmer/component@^1.0.0", "@glimmer/component@^1.0.4":
+"@glimmer/component@^1.0.0":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.1.2.tgz#892ec0c9f0b6b3e41c112be502fde073cf24d17c"
   integrity sha512-XyAsEEa4kWOPy+gIdMjJ8XlzA3qrGH55ZDv6nA16ibalCR17k74BI0CztxuRds+Rm6CtbUVgheCVlcCULuqD7A==
@@ -2220,7 +2163,7 @@
     "@handlebars/parser" "~2.0.0"
     simple-html-tokenizer "^0.5.11"
 
-"@glimmer/tracking@^1.0.0", "@glimmer/tracking@^1.0.4":
+"@glimmer/tracking@^1.0.0":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.1.2.tgz#74e71be07b0a7066518d24044d2665d0cf8281eb"
   integrity sha512-cyV32zsHh+CnftuRX84ALZpd2rpbDrhLhJnTXn9W//QpqdRZ5rdMsxSY9fOsj0CKEc706tmEU299oNnDc0d7tA==
@@ -3092,13 +3035,6 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
-ansi-to-html@^0.6.15:
-  version "0.6.15"
-  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.15.tgz#ac6ad4798a00f6aa045535d7f6a9cb9294eebea7"
-  integrity sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==
-  dependencies:
-    entities "^2.0.0"
-
 ansi-to-html@^0.6.6:
   version "0.6.14"
   resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.14.tgz#65fe6d08bba5dd9db33f44a20aec331e0010dad8"
@@ -3228,7 +3164,7 @@ arraybuffer.slice@~0.0.7:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
   integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
-assert-never@^1.1.0, assert-never@^1.2.1:
+assert-never@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
@@ -3387,11 +3323,6 @@ babel-plugin-filter-imports@^4.0.0:
   dependencies:
     "@babel/types" "^7.7.2"
     lodash "^4.17.15"
-
-babel-plugin-htmlbars-inline-precompile@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz#c4882ea875d0f5683f0d91c1f72e29a4f14b5606"
-  integrity sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==
 
 babel-plugin-htmlbars-inline-precompile@^5.0.0:
   version "5.3.0"
@@ -3924,24 +3855,6 @@ broccoli-funnel@^3.0.8, broccoli-funnel@~3.0.8:
     minimatch "^3.0.0"
     walk-sync "^2.0.2"
 
-broccoli-funnel@ef4/broccoli-funnel#c70d060076e14793e8495571f304a976afc754ac:
-  version "2.0.2-ef4.0"
-  resolved "https://codeload.github.com/ef4/broccoli-funnel/tar.gz/c70d060076e14793e8495571f304a976afc754ac"
-  dependencies:
-    array-equal "^1.0.0"
-    blank-object "^1.0.1"
-    broccoli-plugin "^1.3.0"
-    debug "^2.2.0"
-    fast-ordered-set "^1.0.0"
-    fs-tree-diff "^0.5.3"
-    heimdalljs "^0.2.0"
-    minimatch "^3.0.0"
-    mkdirp "^0.5.0"
-    path-posix "^1.0.0"
-    rimraf "^2.4.3"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^2.2.0"
-
 broccoli-kitchen-sink-helpers@^0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
@@ -4013,13 +3926,6 @@ broccoli-node-info@^2.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-2.1.0.tgz#ca84560e8570ff78565bea1699866ddbf58ad644"
   integrity sha512-l6qDuboJThHfRVVWQVaTs++bFdrFTP0gJXgsWenczc1PavRVUmL1Eyb2swTAXXMpDOnr2zhNOBLx4w9AxkqbPQ==
 
-broccoli-output-wrapper@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz#f1e0b9b2f259a67fd41a380141c3c20b096828e6"
-  integrity sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==
-  dependencies:
-    heimdalljs-logger "^0.1.10"
-
 broccoli-output-wrapper@^3.2.1:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.3.tgz#e5c9de7c881570eb4c0b0d194bb12d9671b25a9b"
@@ -4057,7 +3963,7 @@ broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-p
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.3.0, broccoli-persistent-filter@^2.3.1:
+broccoli-persistent-filter@^2.2.1, broccoli-persistent-filter@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz#4a052e0e0868b344c3a2977e35a3d497aa9eca72"
   integrity sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==
@@ -4119,19 +4025,6 @@ broccoli-plugin@^2.1.0:
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz#2fab6c578219cfcc64f773e9616073313fc8b334"
   integrity sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==
   dependencies:
-    promise-map-series "^0.2.1"
-    quick-temp "^0.1.3"
-    rimraf "^2.3.4"
-    symlink-or-copy "^1.1.8"
-
-broccoli-plugin@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz#54ba6dd90a42ec3db5624063292610e326b1e542"
-  integrity sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==
-  dependencies:
-    broccoli-node-api "^1.6.0"
-    broccoli-output-wrapper "^2.0.0"
-    fs-merger "^3.0.1"
     promise-map-series "^0.2.1"
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
@@ -5504,14 +5397,6 @@ electron-to-chromium@^1.4.284:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.353.tgz#20e9cb4c83a08e35b3314d3fa8988764c105e6b7"
   integrity sha512-IdJVpMHJoBT/nn0GQ02wPfbhogDVpd1ud95lP//FTf5l35wzxKJwibB4HBdY7Q+xKPA1nkZ0UDLOMyRj5U5IAQ==
 
-ember-assign-helper@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/ember-assign-helper/-/ember-assign-helper-0.4.0.tgz#f0a313033656c0d2cbbcb29d55b9cd13f04bc7c1"
-  integrity sha512-GKHhT4HD2fhtDnuBk6eCdCA8XGew9hY7TVs8zjrykegiI7weC0CGtpJscmIG3O0gEEb0d07UTkF2pjfNGLx4Nw==
-  dependencies:
-    ember-cli-babel "^7.26.0"
-    ember-cli-htmlbars "^6.0.0"
-
 ember-auto-import@^2.6.0, ember-auto-import@~2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-2.6.3.tgz#f18d1b93dd10b08ba5496518436f9d56dd4e000a"
@@ -5549,31 +5434,12 @@ ember-auto-import@^2.6.0, ember-auto-import@~2.6.3:
     typescript-memoize "^1.0.0-alpha.3"
     walk-sync "^3.0.0"
 
-"ember-basic-dropdown@^3.1.0 || ^4.0.2":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-4.0.5.tgz#7369fc3d3cd774223510b89ba2ace44b62da5112"
-  integrity sha512-cD0cnL4gjoNNGJ+kMNtGlsikan5v5aVWp5Mkv8fgnLS96EGhmAMlTiRBexmyzK+4Zbe+xOlZKNQva4bZ7FrQGQ==
-  dependencies:
-    "@ember/render-modifiers" "^2.0.4"
-    "@embroider/macros" "^1.2.0"
-    "@embroider/util" "^1.2.0"
-    "@glimmer/component" "^1.0.4"
-    "@glimmer/tracking" "^1.0.4"
-    ember-cli-babel "^7.26.11"
-    ember-cli-htmlbars "^6.0.1"
-    ember-cli-typescript "^4.2.1"
-    ember-element-helper "^0.6.0"
-    ember-get-config "^1.0.2"
-    ember-maybe-in-element "^2.0.3"
-    ember-style-modifier "^0.7.0"
-    ember-truth-helpers "^2.1.0 || ^3.0.0"
-
-ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, ember-cli-babel-plugin-helpers@^1.1.1:
+ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.1.2, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -5606,7 +5472,7 @@ ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.13.0, ember-c
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.10.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.26.0, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11:
+ember-cli-babel@^7.10.0, ember-cli-babel@^7.26.10, ember-cli-babel@^7.26.11:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -5666,48 +5532,6 @@ ember-cli-github-pages@^0.2.2:
     ember-cli-version-checker "^2.1.0"
     rsvp "^4.7.0"
 
-ember-cli-htmlbars@^4.3.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz#d299e4f7eba6f30dc723ee086906cc550beb252e"
-  integrity sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==
-  dependencies:
-    "@ember/edition-utils" "^1.2.0"
-    babel-plugin-htmlbars-inline-precompile "^3.2.0"
-    broccoli-debug "^0.6.5"
-    broccoli-persistent-filter "^2.3.1"
-    broccoli-plugin "^3.1.0"
-    common-tags "^1.8.0"
-    ember-cli-babel-plugin-helpers "^1.1.0"
-    fs-tree-diff "^2.0.1"
-    hash-for-dep "^1.5.1"
-    heimdalljs-logger "^0.1.10"
-    json-stable-stringify "^1.0.1"
-    semver "^6.3.0"
-    strip-bom "^4.0.0"
-    walk-sync "^2.0.2"
-
-ember-cli-htmlbars@^5.2.0:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz#e0cd2fb3c20d85fe4c3e228e6f0590ee1c645ba8"
-  integrity sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==
-  dependencies:
-    "@ember/edition-utils" "^1.2.0"
-    babel-plugin-htmlbars-inline-precompile "^5.0.0"
-    broccoli-debug "^0.6.5"
-    broccoli-persistent-filter "^3.1.2"
-    broccoli-plugin "^4.0.3"
-    common-tags "^1.8.0"
-    ember-cli-babel-plugin-helpers "^1.1.1"
-    ember-cli-version-checker "^5.1.2"
-    fs-tree-diff "^2.0.1"
-    hash-for-dep "^1.5.1"
-    heimdalljs-logger "^0.1.10"
-    json-stable-stringify "^1.0.1"
-    semver "^7.3.4"
-    silent-error "^1.1.1"
-    strip-bom "^4.0.0"
-    walk-sync "^2.2.0"
-
 ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz#eb5b88c7d9083bc27665fb5447a9b7503b32ce4f"
@@ -5730,7 +5554,7 @@ ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.7.1:
     strip-bom "^4.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-htmlbars@^6.0.0, ember-cli-htmlbars@^6.0.1, ember-cli-htmlbars@^6.1.1, ember-cli-htmlbars@~6.2.0:
+ember-cli-htmlbars@^6.1.1, ember-cli-htmlbars@~6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-6.2.0.tgz#18ec48ee1c93f9eed862a64eb24a9d14604f1dfc"
   integrity sha512-j5EGixjGau23HrqRiW/JjoAovg5UBHfjbyN7wX5ekE90knIEqUUj1z/Mo/cTx/J2VepQ2lE6HdXW9LWQ/WdMtw==
@@ -5871,58 +5695,6 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
-ember-cli-typescript@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
-  integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
-  dependencies:
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.4.4"
-    "@babel/plugin-proposal-optional-chaining" "^7.6.0"
-    "@babel/plugin-transform-typescript" "~7.8.0"
-    ansi-to-html "^0.6.6"
-    broccoli-stew "^3.0.0"
-    debug "^4.0.0"
-    ember-cli-babel-plugin-helpers "^1.0.0"
-    execa "^3.0.0"
-    fs-extra "^8.0.0"
-    resolve "^1.5.0"
-    rsvp "^4.8.1"
-    semver "^6.3.0"
-    stagehand "^1.0.0"
-    walk-sync "^2.0.0"
-
-ember-cli-typescript@^4.2.0, ember-cli-typescript@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
-  integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
-  dependencies:
-    ansi-to-html "^0.6.15"
-    broccoli-stew "^3.0.0"
-    debug "^4.0.0"
-    execa "^4.0.0"
-    fs-extra "^9.0.1"
-    resolve "^1.5.0"
-    rsvp "^4.8.1"
-    semver "^7.3.2"
-    stagehand "^1.0.0"
-    walk-sync "^2.2.0"
-
-ember-cli-typescript@^5.0.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz#553030f1ce3e8958b8e4fc34909acd1218cb35f2"
-  integrity sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==
-  dependencies:
-    ansi-to-html "^0.6.15"
-    broccoli-stew "^3.0.0"
-    debug "^4.0.0"
-    execa "^4.0.0"
-    fs-extra "^9.0.1"
-    resolve "^1.5.0"
-    rsvp "^4.8.1"
-    semver "^7.3.2"
-    stagehand "^1.0.0"
-    walk-sync "^2.2.0"
-
 ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
@@ -6054,7 +5826,7 @@ ember-cli@~3.28.5:
     workerpool "^6.1.4"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
   integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
@@ -6075,31 +5847,7 @@ ember-compatibility-helpers@^1.2.1:
     fs-extra "^9.1.0"
     semver "^5.4.1"
 
-ember-concurrency-decorators@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/ember-concurrency-decorators/-/ember-concurrency-decorators-2.0.3.tgz#2816c9a0283b90ba5340fc5b4e0b92ea91f7d6e3"
-  integrity sha512-r6O34YKI/slyYapVsuOPnmaKC4AsmBSwvgcadbdy+jHNj+mnryXPkm+3hhhRnFdlsKUKdEuXvl43lhjhYRLhhA==
-  dependencies:
-    "@ember-decorators/utils" "^6.1.0"
-    ember-cli-babel "^7.19.0"
-    ember-cli-htmlbars "^4.3.1"
-    ember-cli-typescript "^3.1.4"
-
-"ember-concurrency@>=1.0.0 <3":
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-2.3.7.tgz#52d786e37704b9054da1952638797e23714ec0e1"
-  integrity sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/types" "^7.12.13"
-    "@glimmer/tracking" "^1.0.4"
-    ember-cli-babel "^7.26.11"
-    ember-cli-babel-plugin-helpers "^1.1.1"
-    ember-cli-htmlbars "^5.7.1"
-    ember-compatibility-helpers "^1.2.0"
-    ember-destroyable-polyfill "^2.0.2"
-
-ember-destroyable-polyfill@^2.0.2, ember-destroyable-polyfill@^2.0.3:
+ember-destroyable-polyfill@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz#1673ed66609a82268ef270a7d917ebd3647f11e1"
   integrity sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==
@@ -6113,29 +5861,12 @@ ember-disable-prototype-extensions@^1.1.3:
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
   integrity sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=
 
-ember-element-helper@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/ember-element-helper/-/ember-element-helper-0.6.1.tgz#a6fbc5be5f875b5c864ae61bf5c5f81d6de6d936"
-  integrity sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==
-  dependencies:
-    "@embroider/util" "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0"
-    ember-cli-babel "^7.26.11"
-    ember-cli-htmlbars "^6.0.1"
-
 ember-export-application-global@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
-ember-get-config@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-1.1.0.tgz#731e192f1fe8022e06c0dbcbe5622fb8c4c78b87"
-  integrity sha512-diD+HwwY8QqpEk5DnDYfH7onYwl6NOgr1qv1ENbXih+/iiWYUVS/e0S/PlM7A4gdorD9spn1bnisnTLTf49Wpw==
-  dependencies:
-    "@embroider/macros" "^0.50.0 || ^1.0.0"
-    ember-cli-babel "^7.26.6"
-
-ember-in-element-polyfill@^1.0.0, ember-in-element-polyfill@^1.0.1, ember-in-element-polyfill@~1.0.1:
+ember-in-element-polyfill@^1.0.1, ember-in-element-polyfill@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ember-in-element-polyfill/-/ember-in-element-polyfill-1.0.1.tgz#143504445bb4301656a2eaad42644d684f5164dd"
   integrity sha512-eHs+7D7PuQr8a1DPqsJTsEyo3FZ1XuH6WEZaEBPDa9s0xLlwByCNKl8hi1EbXOgvgEZNHHi9Rh0vjxyfakrlgg==
@@ -6163,15 +5894,14 @@ ember-maybe-import-regenerator@^1.0.0:
     ember-cli-babel "^7.26.6"
     regenerator-runtime "^0.13.2"
 
-ember-maybe-in-element@2.0.1, ember-maybe-in-element@^2.0.3:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-2.0.1.tgz#fa3a26cc2c522a27129d6528b400b9c820943be6"
-  integrity sha512-Mp/HTVOGu9H7kWoq5xncVLEvPFgRuHdsqWyZ1v/gBA8Y3d2q2LdrmDK9Zg59i+cCs4oa9LrMeFyKMAbBS3vyDw==
+ember-maybe-in-element@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-2.1.0.tgz#f7bd8e41ca90a4f8038d919a9c135cbe7a7f271b"
+  integrity sha512-6WAzPbf4BNQIQzkur2+zRJJJ/PKQoujIYgFjrpj3fOPy8iRlxVUm0/B41qbFyg1LE6bVbg0cWbuESWEvJ9Rswg==
   dependencies:
-    ember-cli-babel "^7.21.0"
-    ember-cli-htmlbars "^5.2.0"
-    ember-cli-version-checker "^5.1.1"
-    ember-in-element-polyfill "^1.0.0"
+    ember-cli-babel "^7.26.11"
+    ember-cli-htmlbars "^6.1.1"
+    ember-cli-version-checker "^5.1.2"
 
 ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
@@ -6181,35 +5911,6 @@ ember-modifier-manager-polyfill@^1.2.0:
     ember-cli-babel "^7.10.0"
     ember-cli-version-checker "^2.1.2"
     ember-compatibility-helpers "^1.2.0"
-
-ember-modifier@^3.0.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
-  integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==
-  dependencies:
-    ember-cli-babel "^7.26.6"
-    ember-cli-normalize-entity-name "^1.0.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^5.0.0"
-    ember-compatibility-helpers "^1.2.5"
-
-ember-power-select@~5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-5.0.4.tgz#4af485fb7e1e1eca1bedd523892c82c672935dac"
-  integrity sha512-FLVShZr3cYdLzymP+/0rXkfH5tD/FD958kynY86MWvn7ZyL2tXowlgVKY08n+PJHdo/vCrzqubRYckvXRSH6Bg==
-  dependencies:
-    "@embroider/util" "^1.0.0"
-    "@glimmer/component" "^1.0.4"
-    "@glimmer/tracking" "^1.0.4"
-    ember-assign-helper "^0.4.0"
-    ember-basic-dropdown "^3.1.0 || ^4.0.2"
-    ember-cli-babel "^7.26.0"
-    ember-cli-htmlbars "^6.0.0"
-    ember-cli-typescript "^4.2.0"
-    ember-concurrency ">=1.0.0 <3"
-    ember-concurrency-decorators "^2.0.0"
-    ember-text-measurer "^0.6.0"
-    ember-truth-helpers "^2.1.0 || ^3.0.0"
 
 ember-qunit@^6.2.0:
   version "6.2.0"
@@ -6291,14 +5992,6 @@ ember-source@~3.28.11:
     semver "^7.3.4"
     silent-error "^1.1.1"
 
-ember-style-modifier@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/ember-style-modifier/-/ember-style-modifier-0.7.0.tgz#85b3dfd7e4bc2bd546df595f2dab4fb141cf7d87"
-  integrity sha512-iDzffiwJcb9j6gu3g8CxzZOTvRZ0BmLMEFl+uyqjiaj72VVND9+HbLyQRw1/ewPAtinhSktxxTTdwU/JO+stLw==
-  dependencies:
-    ember-cli-babel "^7.26.6"
-    ember-modifier "^3.0.0"
-
 ember-svg-jar@~2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/ember-svg-jar/-/ember-svg-jar-2.4.2.tgz#7ea2c987cc188647cdd01842631d6bd0cdbe4f22"
@@ -6334,15 +6027,7 @@ ember-template-imports@^3.4.2:
     string.prototype.matchall "^4.0.6"
     validate-peer-dependencies "^1.1.0"
 
-ember-text-measurer@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ember-text-measurer/-/ember-text-measurer-0.6.0.tgz#140eda044fd7d4d7f60f654dd30da79c06922b2e"
-  integrity sha512-/aZs2x2i6kT4a5tAW+zenH2wg8AbRK9jKxLkbVsKl/1ublNl27idVRdov1gJ+zgWu3DNK7whcfVycXtlaybYQw==
-  dependencies:
-    ember-cli-babel "^7.19.0"
-    ember-cli-htmlbars "^4.3.1"
-
-"ember-truth-helpers@^2.1.0 || ^3.0.0", ember-truth-helpers@^3.1.1:
+ember-truth-helpers@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz#434715926d72bcc63b8a115dec09745fda4474dc"
   integrity sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==
@@ -6933,23 +6618,7 @@ execa@^2.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^3.0.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
-  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
-  dependencies:
-    cross-spawn "^7.0.0"
-    get-stream "^5.0.0"
-    human-signals "^1.1.1"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.0"
-    onetime "^5.1.0"
-    p-finally "^2.0.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
-
-execa@^4.0.0, execa@^4.1.0:
+execa@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -7518,7 +7187,7 @@ fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1, fs-extra@^9.1.0:
+fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -7528,7 +7197,7 @@ fs-extra@^9.0.1, fs-extra@^9.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-merger@^3.0.1, fs-merger@^3.1.0:
+fs-merger@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.1.0.tgz#f30f74f6c70b2ff7333ec074f3d2f22298152f3b"
   integrity sha512-RZ9JtqugaE8Rkt7idO5NSwcxEGSDZpLmVFjtVQUm3f+bWun7JAU6fKyU6ZJUeUnKdJwGx8uaro+K4QQfOR7vpA==
@@ -9492,7 +9161,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@4.17.21, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11668,7 +11337,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve-package-path@^1.0.11, resolve-package-path@^1.2.2, resolve-package-path@^1.2.6:
+resolve-package-path@^1.0.11, resolve-package-path@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/resolve-package-path/-/resolve-package-path-1.2.7.tgz#2a7bc37ad96865e239330e3102c31322847e652e"
   integrity sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==
@@ -11712,7 +11381,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
Here is a suggestion for how the migration to the Glimmer Component could look like.
Unfortunately, one of the drawbacks is that the "parentFinder" hack stopped working and we need somehow determine the parent element. The best way to fix it I've made up is to render a dummy hidden element. 

That same element is used to track `isShown` argument (as `observes` is no longer available) changes until the attached element is rendered (and can track the same change by itself).

However, this change should fix the following issues:
- https://github.com/tylerturdenpants/ember-attacher/issues/604
- https://github.com/tylerturdenpants/ember-attacher/issues/141
- https://github.com/tylerturdenpants/ember-attacher/issues/121 (probably it is already fixed and should be closed)

This PR also removes the "ember-power-select" as a bit redundant in favour of the native `select` in the dummy app. For some reason, it caused the build and/or runtime errors after attempting to update `ember-source` or the `power-select` itself. Also, it lead to the `ember-maybe-in-element` version conflicts

What do you think?