### PR TITLE
Prevent overflow by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@ Below is a list of all available options, along with their defaults.
   // than the bubbling phase. This should be set to true when there are elements on the page that
   // are stopping event propagation in the bubbling phase, and as a result preventing correct
   // showing and hiding of popovers and tooltips.
-  useCapture: false
+  useCapture: false,
+
+  // The default padding if collision happens. Set "false" if no collision prevention needed 
+  overflowPadding: 5 
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Download count all time](https://img.shields.io/npm/dt/ember-attacher.svg)](https://www.npmjs.com/package/ember-attacher)
 [![npm](https://img.shields.io/npm/dm/ember-attacher.svg)](https://www.npmjs.com/package/ember-attacher)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-attacher.svg)](http://emberobserver.com/addons/ember-attacher)
-[![Build Status](https://travis-ci.org/kybishop/ember-attacher.svg?branch=master)](https://travis-ci.org/kybishop/ember-attacher)
+[![GitHub CI](https://github.com/tylerturdenpants/ember-attacher/actions/workflows/ci.yml/badge.svg)](https://github.com/tylerturdenpants/ember-attacher/actions/workflows/ci.yml)
 
 ## Compatibility
 

--- a/addon/defaults.js
+++ b/addon/defaults.js
@@ -20,5 +20,6 @@ export default {
   showOn: 'mouseenter focus',
   style: null,
   tooltipClass: 'ember-attacher-floating ember-attacher-tooltip',
-  useCapture: false
+  useCapture: false,
+  overflowPadding: 5
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-attacher",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Tooltips and popovers for Ember.js apps",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-attacher",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Tooltips and popovers for Ember.js apps",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
In the Popper.js version the overflow was prevented by default. As there is no way to provide the default middleware in the `environment.js`, I thought it will be nice to provide an option to prevent the attached element from being overflowed.  

Inspired by the section in the [migration guide](https://floating-ui.com/docs/migration#:~:text=If%20you%E2%80%99d%20like%20to%20directly%20match%20Popper%E2%80%99s%20default%20behavior%20to%20prevent%20collisions).