### PR TITLE
Fix test error caused by wrong endAsync call

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -517,7 +517,7 @@ export default class AttachPopover extends Component {
     if (!this._floatingElement) {
       this._animationTimeout = requestAnimationFrame(() => {
         animationTestWaiter.endAsync(this._animationTimeout);
-        this._animationTimeout = this._hide();
+        this._hide();
       });
       animationTestWaiter.beginAsync(this._animationTimeout);
       return;


### PR DESCRIPTION
In some cases the tests might be failed with error `Uncaught Error: endAsync called with no preceding beginAsync call` thrown caused by the wrong (undefined) test waiter token.