### PR TITLE
Fix the stripInProduction for the apps and the runtime error

### DIFF
--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -834,8 +834,10 @@ export default class AttachPopover extends Component {
   _cancelAnimation() {
     cancelAnimationFrame(this._animationTimeout);
 
-    if (animationTestWaiter.items.get(this._animationTimeout)) {
-      animationTestWaiter.endAsync(this._animationTimeout);
-    }
+    stripInProduction(() => {
+      if (animationTestWaiter.items?.get(this._animationTimeout)) {
+        animationTestWaiter.endAsync(this._animationTimeout);
+      }
+    })
   }
 }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,17 @@ const Funnel = require('broccoli-funnel');
 module.exports = {
   name: require('./package').name,
 
-  included(app) {
+  included(parent) {
     this._super.included.apply(this, arguments);
+    let app = this.app;
+
+    while (!app && parent) {
+      if (parent.app) {
+        app = parent.app;
+      } else {
+        parent = parent.parent;
+      }
+    }
 
     this._env = app.env;
     this._setupBabelOptions(app.env);


### PR DESCRIPTION
This PR fixes the `_cancelAnimation` issue that throws an error during the runtime (see the screenshot).
This happens because `animationTestWaiter.items` is undefined in production.
 
The fix for the `stripInProduction` is inspired by the hack described in [Ember-CLI](https://github.com/ember-cli/ember-cli/issues/4031#issuecomment-100018545) and fixes the [described issue](https://github.com/tylerturdenpants/ember-attacher/issues/805).

```Cannot read properties of undefined (reading 'get') ```
<img width="627" alt="image" src="https://github.com/tylerturdenpants/ember-attacher/assets/36226946/60d84f20-7cbe-4db0-b2da-279df688e18c">
