### PR TITLE
Remove the "beyond ember 3.24" support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 
   The addon's dummy application needs a serious upgrade.  I [@tylerturdenpants](https://github.com/tylerturdenpants) have removed as much orf the support on flexi and flexi styles that I can, but the dummy app will still produces warnings regarding SASS division.
 
-  Additionally, this app likely has support beyond ember 3.24, but test fail locally since not all babel related issues during testing have been resolved.
-
   As the only supporter of this addon, a father, and a full time employee at a software company, I really need the help to fully pull flexi out and to revamp the dummy app.  Once these blockers are removed I can do the work to bring this addon into the future.
 
 ----


### PR DESCRIPTION
This part of the "Note" section is not relevant -- `ember-attacher` is compatible with Ember `>=3.16.10 <=5.0.0` and the tests don't fail.

<img width="500" alt="image" src="https://github.com/tylerturdenpants/ember-attacher/assets/36226946/2574201f-2313-4c1b-8576-b5f78f65a508">
