### PR TITLE
Fix the "cancelAnimationFrame is not defined" error in fastboot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -71,7 +71,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -832,7 +832,7 @@ export default class AttachPopover extends Component {
   }
 
   _cancelAnimation() {
-    if (typeOf(cancelAnimationFrame) !== 'function') {
+    if (typeof cancelAnimationFrame !== 'function') {
       return;
     }
 

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -832,6 +832,10 @@ export default class AttachPopover extends Component {
   }
 
   _cancelAnimation() {
+    if (!this._animationTimeout || !cancelAnimationFrame) {
+      return;
+    }
+
     cancelAnimationFrame(this._animationTimeout);
 
     stripInProduction(() => {

--- a/addon/components/attach-popover.js
+++ b/addon/components/attach-popover.js
@@ -832,7 +832,7 @@ export default class AttachPopover extends Component {
   }
 
   _cancelAnimation() {
-    if (!this._animationTimeout || !cancelAnimationFrame) {
+    if (typeOf(cancelAnimationFrame) !== 'function') {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ember-in-element-polyfill": "^1.0.1"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
I am not sure what are the steps to reproduce, but there is an error caught by bugsnag after bumping ember-attacher: `ReferenceError: cancelAnimationFrame is not defined`. This PR should fix the described issue.