### PR TITLE
Move `@ember/test-waiters` to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Just drop an `<AttachTooltip/>` or `<AttachPopover/>` in a parent and your float
 <button class="other-button">
   No click me!
 
-  <AttachPopover
+  <AttachPopover 
       @class='ember-attacher'
       @hideOn='click'
       @isShown={{true}}
@@ -93,11 +93,11 @@ Below is a list of all available options, along with their defaults.
 
   // Whether or not an arrow will be displayed next to the attachment.
   arrow: false,
-
+    
   // Add listeners that will automatically call an update function
   // Pass `true` to use the Floating UI default options or Options object to override them
   // Example: { ancestorScroll: false }
-  // For more details see https://floating-ui.com/docs/autoUpdate
+  // For more details see https://floating-ui.com/docs/autoUpdate 
   autoUpdate: false,
 
   // A class that will be applied to the attachment.
@@ -178,8 +178,8 @@ Below is a list of all available options, along with their defaults.
   // showing and hiding of popovers and tooltips.
   useCapture: false,
 
-  // The default padding if collision happens. Set "false" if no collision prevention needed
-  overflowPadding: 5
+  // The default padding if collision happens. Set "false" if no collision prevention needed 
+  overflowPadding: 5 
 }
 ```
 
@@ -265,7 +265,7 @@ test('example', async function(assert) {
     <button id="toggle">
       Click me, captain!
 
-      <AttachPopover
+      <AttachPopover 
           @id='attachment'
           @hideOn='click'
           @showOn='click'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ----
 
-* Ember.js v3.20 or above
+* Ember.js v3.20 through v5.12
 * Ember CLI v3.13 or above
 * Node.js v12 or above
 
@@ -37,7 +37,7 @@ Just drop an `<AttachTooltip/>` or `<AttachPopover/>` in a parent and your float
 <button class="other-button">
   No click me!
 
-  <AttachPopover 
+  <AttachPopover
       @class='ember-attacher'
       @hideOn='click'
       @isShown={{true}}
@@ -93,11 +93,11 @@ Below is a list of all available options, along with their defaults.
 
   // Whether or not an arrow will be displayed next to the attachment.
   arrow: false,
-    
+
   // Add listeners that will automatically call an update function
   // Pass `true` to use the Floating UI default options or Options object to override them
   // Example: { ancestorScroll: false }
-  // For more details see https://floating-ui.com/docs/autoUpdate 
+  // For more details see https://floating-ui.com/docs/autoUpdate
   autoUpdate: false,
 
   // A class that will be applied to the attachment.
@@ -178,8 +178,8 @@ Below is a list of all available options, along with their defaults.
   // showing and hiding of popovers and tooltips.
   useCapture: false,
 
-  // The default padding if collision happens. Set "false" if no collision prevention needed 
-  overflowPadding: 5 
+  // The default padding if collision happens. Set "false" if no collision prevention needed
+  overflowPadding: 5
 }
 ```
 
@@ -265,7 +265,7 @@ test('example', async function(assert) {
     <button id="toggle">
       Click me, captain!
 
-      <AttachPopover 
+      <AttachPopover
           @id='attachment'
           @hideOn='click'
           @showOn='click'

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "@ember/test-waiters": "^3.1.0",
     "@floating-ui/dom": "^1.6.12",
     "babel-plugin-filter-imports": "^4.0.0",
     "broccoli-funnel": "~3.0.8",
@@ -48,7 +49,6 @@
     "@ember/render-modifiers": "^2.0.5",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "~2.9.4",
-    "@ember/test-waiters": "^3.1.0",
     "@embroider/test-setup": "^3.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -33,7 +33,16 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-5.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),


### PR DESCRIPTION
Resolves #992 by moving `@ember/test-waiters` from package.json `devDependencies` to `dependencies`.

Confirmed this was fixed in my Ember 5.8 app that also uses `ember-sortable` (which [requires](https://github.com/adopted-ember-addons/ember-sortable/blob/master/addon/package.json#L72) a peer dependency of `"@ember/test-waiters": ">= 3.0.1",`) as follows:
- Removed `package-lock.json` and `node_modules/`
- Re-ran `npm install` (which generated a new package-lock with `@ember/test-waiters` v4 for ember-sortable)
- Booted `ember serve` and saw the same error logged in 992
- Replaced the `ember-attacher` entry in my package.json with `"ember-attacher": "gorner/ember-attacher#move-test-waiters-to-deps",` (i.e. this branch)
- Ran `ember serve` again and saw everything was working as expected

A few notes:
- Although there is now a v4 of `test-waiters`, I've stuck with v3 as there are [breaking changes](https://github.com/emberjs/ember-test-waiters/pull/476) that require dropping support for Ember <4.0, which would imply a major version bump to `ember-attacher`. This will probably be needed in the near future, but it doesn't appear to be needed to resolve the current issue.
- The `ember-try` run for `ember-release` (Ember 6.0) fails due to breaking changes, specifically the requirement to switch to component template co-location. I see there is a separate issue for this already (#978) so for now I am marking the `ember-release` run as `allowedToFail: true`, adding a separate scenario for Ember 5.12, and indicating in the README that the addon is not yet compatible with Ember 6+.
- In the issue I noted that it might make sense to use `peerDependencies` instead so app developers could specify the version of `test-waiters` that works for them. For now it doesn't really make a difference because this package only works with v3 of `test-waiters` anyway. It might make more sense once the Ember 6.x compatibility issues are cleared.